### PR TITLE
chore: refactor Assertion.prototype.translateZodError => AssertionError.fromZodError

### DIFF
--- a/src/assertion/assertion-sync.ts
+++ b/src/assertion/assertion-sync.ts
@@ -217,7 +217,7 @@ export class BupkisAssertionSchemaSync<
 {
   override execute(
     parsedValues: ParsedValues<Parts>,
-    args: unknown[],
+    _args: unknown[],
     stackStartFn: (...args: any[]) => any,
     parseResult?: ParsedResult<Parts>,
   ): void {

--- a/src/assertion/assertion.ts
+++ b/src/assertion/assertion.ts
@@ -13,7 +13,7 @@ import Debug from 'debug';
 import slug from 'slug';
 import { type ArrayValues } from 'type-fest';
 import { inspect } from 'util';
-import { z } from 'zod/v4';
+import { type z } from 'zod/v4';
 
 import { kStringLiteral } from '../constant.js';
 import { AssertionError } from '../error.js';
@@ -186,22 +186,7 @@ export abstract class BupkisAssertion<
     zodError: z.ZodError,
     ...values: ParsedValues<Parts>
   ): AssertionError {
-    const flat = z.flattenError(zodError);
-
-    let pretty = flat.formErrors.join('; ');
-    for (const [keypath, errors] of Object.entries(flat.fieldErrors)) {
-      pretty += `; ${keypath}: ${(errors as unknown[]).join('; ')}`;
-    }
-
-    const [actual, ...expected] = values as unknown as [unknown, ...unknown[]];
-
-    return new AssertionError({
-      actual,
-      expected: expected.length === 1 ? expected[0] : expected,
-      message: `Assertion ${this} failed: ${pretty}`,
-      operator: `${this}`,
-      stackStartFn,
-    });
+    return AssertionError.fromZodError(zodError, stackStartFn, values);
   }
 
   /**

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,5 +1,6 @@
 import { AssertionError as NodeAssertionError } from 'node:assert';
 import { describe, it } from 'node:test';
+import { z } from 'zod/v4';
 
 import {
   kBupkisAssertionError,
@@ -79,6 +80,248 @@ describe('AssertionError', () => {
       expect(AssertionError.isAssertionError(42), 'to be false');
       expect(AssertionError.isAssertionError({}), 'to be false');
       expect(AssertionError.isAssertionError([]), 'to be false');
+    });
+  });
+
+  describe('fromZodError', () => {
+    it('should create AssertionError from ZodError with single value', () => {
+      const schema = z.string();
+      const result = schema.safeParse(42);
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        const stackStartFn = () => {};
+        const values = [42] as readonly [unknown];
+        const error = AssertionError.fromZodError(
+          result.error,
+          stackStartFn,
+          values,
+        );
+
+        expect(error, 'to be an instance of', AssertionError);
+        expect(error.actual, 'to equal', 42);
+        expect(error.expected, 'to be an array');
+        expect(error.expected, 'to have length', 0);
+        expect(error.message, 'to contain', 'Assertion');
+        expect(error.message, 'to contain', 'failed');
+        expect(error.operator, 'to contain', 'AssertionError');
+      }
+    });
+
+    it('should create AssertionError from ZodError with multiple values', () => {
+      const schema = z.number().gt(10);
+      const result = schema.safeParse(5);
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        const stackStartFn = () => {};
+        const values = [5, 10] as unknown as readonly [unknown];
+        const error = AssertionError.fromZodError(
+          result.error,
+          stackStartFn,
+          values,
+        );
+
+        expect(error, 'to be an instance of', AssertionError);
+        expect(error.actual, 'to equal', 5);
+        expect(error.expected, 'to equal', 10);
+        expect(error.message, 'to contain', 'Assertion');
+        expect(error.message, 'to contain', 'failed');
+      }
+    });
+
+    it('should create AssertionError with multiple expected values as array', () => {
+      const schema = z.union([z.string(), z.number()]);
+      const result = schema.safeParse(true);
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        const stackStartFn = () => {};
+        const values = [true, 'string', 42, 'other'] as unknown as readonly [
+          unknown,
+        ];
+        const error = AssertionError.fromZodError(
+          result.error,
+          stackStartFn,
+          values,
+        );
+
+        expect(error, 'to be an instance of', AssertionError);
+        expect(error.actual, 'to equal', true);
+        expect(error.expected, 'to be an array');
+        expect(error.expected, 'to have length', 3);
+        expect(error.expected, 'to contain', 'string');
+        expect(error.expected, 'to contain', 42);
+        expect(error.expected, 'to contain', 'other');
+      }
+    });
+
+    it('should include form errors in message', () => {
+      // Create a schema that will generate form errors
+      const schema = z.string().min(5, 'String too short');
+      const result = schema.safeParse('hi');
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        const stackStartFn = () => {};
+        const values = ['hi'] as readonly [unknown];
+        const error = AssertionError.fromZodError(
+          result.error,
+          stackStartFn,
+          values,
+        );
+
+        expect(error.message, 'to contain', 'String too short');
+      }
+    });
+
+    it('should include field errors in message', () => {
+      // Create a schema that will generate field errors
+      const schema = z.object({
+        age: z.number().positive('Age must be positive'),
+        name: z.string().min(3, 'Name too short'),
+      });
+      const result = schema.safeParse({ age: -5, name: 'a' });
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        const stackStartFn = () => {};
+        const values = [{ age: -5, name: 'a' }] as readonly [unknown];
+        const error = AssertionError.fromZodError(
+          result.error,
+          stackStartFn,
+          values,
+        );
+
+        expect(error.message, 'to contain', 'name');
+        expect(error.message, 'to contain', 'Name too short');
+        expect(error.message, 'to contain', 'age');
+        expect(error.message, 'to contain', 'Age must be positive');
+      }
+    });
+
+    it('should combine form and field errors in message', () => {
+      // Create a custom schema with both form and field errors
+      const schema = z
+        .object({
+          password: z.string().min(8, 'Password too short'),
+          username: z.string().min(3, 'Username too short'),
+        })
+        .refine((data) => data.username !== data.password, {
+          message: 'Username and password cannot be the same',
+        });
+
+      const result = schema.safeParse({ password: 'a', username: 'a' });
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        const stackStartFn = () => {};
+        const values = [{ password: 'a', username: 'a' }] as readonly [unknown];
+        const error = AssertionError.fromZodError(
+          result.error,
+          stackStartFn,
+          values,
+        );
+
+        // Should contain field errors
+        expect(error.message, 'to contain', 'username');
+        expect(error.message, 'to contain', 'Username too short');
+        expect(error.message, 'to contain', 'password');
+        expect(error.message, 'to contain', 'Password too short');
+        // Should contain form error
+        expect(
+          error.message,
+          'to contain',
+          'Username and password cannot be the same',
+        );
+      }
+    });
+
+    it('should preserve stackStartFn for stack trace management', () => {
+      const schema = z.string();
+      const result = schema.safeParse(42);
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        function outerFunction() {
+          return innerFunction();
+        }
+
+        function innerFunction() {
+          return createErrorFromZod();
+        }
+
+        function createErrorFromZod() {
+          const values = [42] as readonly [unknown];
+          return AssertionError.fromZodError(
+            result.error!,
+            createErrorFromZod,
+            values,
+          );
+        }
+
+        const error = outerFunction();
+
+        // Error should have stack trace
+        expect(error.stack, 'to be a string');
+
+        // Stack should exclude createErrorFromZod (due to stackStartFn)
+        expect(error.stack, 'not to contain', 'createErrorFromZod');
+
+        // Stack should still include the outer functions
+        expect(error.stack, 'to contain', 'innerFunction');
+        expect(error.stack, 'to contain', 'outerFunction');
+      }
+    });
+
+    it('should return AssertionError instance with correct properties', () => {
+      const schema = z.number();
+      const result = schema.safeParse('not a number');
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        const stackStartFn = () => {};
+        const values = ['not a number'] as readonly [unknown];
+        const error = AssertionError.fromZodError(
+          result.error,
+          stackStartFn,
+          values,
+        );
+
+        // Should be proper AssertionError
+        expect(error, 'to be an instance of', AssertionError);
+        expect(error, 'to be an instance of', NodeAssertionError);
+        expect(error.name, 'to equal', 'AssertionError');
+        expect(error[kBupkisAssertionError], 'to be true');
+
+        // Should have expected AssertionError properties
+        expect(error.actual, 'to equal', 'not a number');
+        expect(error.message, 'to be a string');
+        expect(error.operator, 'to be a string');
+        expect(error.stack, 'to be a string');
+      }
+    });
+
+    it('should handle empty values array gracefully', () => {
+      const schema = z.string();
+      const result = schema.safeParse(42);
+      expect(result.success, 'to be false');
+
+      if (!result.success) {
+        const stackStartFn = () => {};
+        const values = [] as const;
+        const error = AssertionError.fromZodError(
+          result.error,
+          stackStartFn,
+          // @ts-expect-error should really not be empty
+          values,
+        );
+
+        expect(error, 'to be an instance of', AssertionError);
+        expect(error.actual, 'to be undefined');
+        expect(error.expected, 'to be an array');
+        expect(error.expected, 'to have length', 0);
+      }
     });
   });
 });


### PR DESCRIPTION
chore: refactor Assertion.prototype.translateZodError => AssertionError.fromZodError

fix: restore caching for async schema assertions