### PR TITLE
feat(assertions): new date assertions

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -67,7 +67,8 @@
     "tyvm",
     "wagoid",
     "wallabyjs",
-    "conjunctify"
+    "conjunctify",
+    "conjunctified"
   ],
   "words": [
     "bupkis",

--- a/site/assertions/date.md
+++ b/site/assertions/date.md
@@ -5,7 +5,7 @@ category: Assertions
 
 ## Date & Time Assertions
 
-These assertions test Date objects and time-related values.
+These assertions test Date objects, time-related values, durations, and temporal relationships.
 
 ### `{unknown} to be a Date`
 
@@ -35,4 +35,405 @@ expect(1704067200000, 'to be a Date'); // Unix timestamp
 ```js
 expect('2024-01-01', 'not to be a date');
 expect(1704067200000, 'not to be a Date');
+```
+
+### `{unknown} to be a valid date`
+
+> ✏️ Aliases:
+>
+>     {unknown} to be a valid date
+>     {unknown} to be date-like
+
+**Success**:
+
+```js
+expect(new Date(), 'to be a valid date');
+expect('2024-01-01', 'to be date-like');
+expect(1704067200000, 'to be a valid date'); // Unix timestamp
+```
+
+**Failure**:
+
+```js
+expect('invalid-date', 'to be a valid date');
+// AssertionError: Expected 'invalid-date' to be a valid date
+expect(NaN, 'to be date-like');
+```
+
+**Negation**:
+
+```js
+expect('invalid-date', 'not to be a valid date');
+expect(NaN, 'not to be date-like');
+```
+
+### `{unknown} to be today`
+
+**Success**:
+
+```js
+expect(new Date(), 'to be today'); // passes if run today
+expect(new Date().toISOString().split('T')[0], 'to be today');
+```
+
+**Failure**:
+
+```js
+expect(new Date('2022-01-01'), 'to be today');
+// AssertionError: Expected 2022-01-01T00:00:00.000Z to be today
+```
+
+**Negation**:
+
+```js
+expect(new Date('2022-01-01'), 'not to be today');
+```
+
+### `{date-like} to be before {date-like}`
+
+**Success**:
+
+```js
+expect(new Date('2022-01-01'), 'to be before', new Date('2023-01-01'));
+expect('2022-01-01', 'to be before', '2023-01-01');
+expect(1640995200000, 'to be before', new Date('2023-01-01'));
+```
+
+**Failure**:
+
+```js
+expect(new Date('2023-01-01'), 'to be before', new Date('2022-01-01'));
+// AssertionError: Expected 2023-01-01T00:00:00.000Z to be before 2022-01-01T00:00:00.000Z
+```
+
+**Negation**:
+
+```js
+expect(new Date('2023-01-01'), 'not to be before', new Date('2022-01-01'));
+```
+
+### `{date-like} to be after {date-like}`
+
+**Success**:
+
+```js
+expect(new Date('2023-01-01'), 'to be after', new Date('2022-01-01'));
+expect('2023-01-01', 'to be after', '2022-01-01');
+expect(Date.now(), 'to be after', new Date('2020-01-01'));
+```
+
+**Failure**:
+
+```js
+expect(new Date('2022-01-01'), 'to be after', new Date('2023-01-01'));
+// AssertionError: Expected 2022-01-01T00:00:00.000Z to be after 2023-01-01T00:00:00.000Z
+```
+
+**Negation**:
+
+```js
+expect(new Date('2022-01-01'), 'not to be after', new Date('2023-01-01'));
+```
+
+### `{date-like} to be between {date-like} and {date-like}`
+
+**Success**:
+
+```js
+expect(
+  new Date('2022-06-01'),
+  'to be between',
+  new Date('2022-01-01'),
+  new Date('2022-12-31'),
+);
+expect('2022-06-01', 'to be between', '2022-01-01', 'and', '2022-12-31');
+```
+
+**Failure**:
+
+```js
+expect(
+  new Date('2023-01-01'),
+  'to be between',
+  new Date('2022-01-01'),
+  'and',
+  new Date('2022-12-31'),
+);
+// AssertionError: Expected 2023-01-01T00:00:00.000Z to be between 2022-01-01T00:00:00.000Z and 2022-12-31T00:00:00.000Z
+```
+
+**Negation**:
+
+```js
+expect(
+  new Date('2023-01-01'),
+  'not to be between',
+  new Date('2022-01-01'),
+  new Date('2022-12-31'),
+);
+```
+
+### `{date-like} to be within {duration} from now`
+
+**Success**:
+
+```js
+expect(new Date(), 'to be within', '1 hour from now');
+expect(new Date(Date.now() - 30000), 'to be within', '1 minute from now'); // 30 seconds ago
+```
+
+**Failure**:
+
+```js
+expect(new Date(Date.now() - 3600000), 'to be within', '30 minutes from now');
+// AssertionError: Expected date to be within 30 minutes from now
+```
+
+**Negation**:
+
+```js
+expect(
+  new Date(Date.now() - 3600000),
+  'not to be within',
+  '30 minutes from now',
+);
+```
+
+### `{date-like} to be within {duration} ago`
+
+**Success**:
+
+```js
+expect(new Date(Date.now() - 1800000), 'to be within', '1 hour ago'); // 30 minutes ago
+expect(new Date(Date.now() - 60000), 'to be within', '5 minutes ago'); // 1 minute ago
+```
+
+**Failure**:
+
+```js
+expect(new Date(Date.now() + 1800000), 'to be within', '1 hour ago'); // future date
+// AssertionError: Expected future date to be within 1 hour ago
+```
+
+**Negation**:
+
+```js
+expect(new Date(Date.now() + 1800000), 'not to be within', '1 hour ago');
+```
+
+### `{date-like} to be at least {duration} from now`
+
+**Success**:
+
+```js
+expect(new Date(Date.now() + 7200000), 'to be at least', '1 hour from now'); // 2 hours from now
+expect(new Date(Date.now() + 86400000), 'to be at least', '12 hours from now'); // 1 day from now
+```
+
+**Failure**:
+
+```js
+expect(new Date(Date.now() + 1800000), 'to be at least', '1 hour from now'); // 30 minutes from now
+// AssertionError: Expected date to be at least 1 hour from now
+```
+
+**Negation**:
+
+```js
+expect(new Date(Date.now() + 1800000), 'not to be at least', '1 hour from now');
+```
+
+### `{date-like} to be at least {duration} ago`
+
+**Success**:
+
+```js
+expect(new Date(Date.now() - 7200000), 'to be at least', '1 hour ago'); // 2 hours ago
+expect(new Date(Date.now() - 86400000), 'to be at least', '12 hours ago'); // 1 day ago
+```
+
+**Failure**:
+
+```js
+expect(new Date(Date.now() - 1800000), 'to be at least', '1 hour ago'); // 30 minutes ago
+// AssertionError: Expected date to be at least 1 hour ago
+```
+
+**Negation**:
+
+```js
+expect(new Date(Date.now() - 1800000), 'not to be at least', '1 hour ago');
+```
+
+### `{date-like} to be the same date as {date-like}`
+
+**Success**:
+
+```js
+expect(
+  new Date('2023-01-01T10:00:00'),
+  'to be the same date as',
+  new Date('2023-01-01T15:30:00'),
+); // same date, different times
+expect('2023-01-01', 'to be the same date as', new Date('2023-01-01T23:59:59'));
+```
+
+**Failure**:
+
+```js
+expect(
+  new Date('2023-01-01'),
+  'to be the same date as',
+  new Date('2023-01-02'),
+);
+// AssertionError: Expected 2023-01-01T00:00:00.000Z to be the same date as 2023-01-02T00:00:00.000Z
+```
+
+**Negation**:
+
+```js
+expect(
+  new Date('2023-01-01'),
+  'not to be the same date as',
+  new Date('2023-01-02'),
+);
+```
+
+### `{date-like} to equal {date-like} within {duration}`
+
+**Success**:
+
+```js
+const date1 = new Date('2023-01-01T10:00:00.000Z');
+const date2 = new Date('2023-01-01T10:00:00.500Z');
+expect(date1, 'to equal', date2, 'within', '1 second'); // 500ms difference
+expect(date1, 'to equal', date2, 'within', '1 minute');
+```
+
+**Failure**:
+
+```js
+const date1 = new Date('2023-01-01T10:00:00.000Z');
+const date2 = new Date('2023-01-01T10:00:00.500Z');
+expect(date1, 'to equal', date2, 'within', '100 milliseconds');
+// AssertionError: Expected dates to be equal within 100 milliseconds
+```
+
+**Negation**:
+
+```js
+expect(date1, 'not to equal', date2, 'within', '100 milliseconds');
+```
+
+### `{unknown} to be in the past`
+
+**Success**:
+
+```js
+expect(new Date('2022-01-01'), 'to be in the past');
+expect(new Date(Date.now() - 1000), 'to be in the past'); // 1 second ago
+expect('2020-01-01', 'to be in the past');
+```
+
+**Failure**:
+
+```js
+expect(new Date('2030-01-01'), 'to be in the past');
+// AssertionError: Expected 2030-01-01T00:00:00.000Z to be in the past
+```
+
+**Negation**:
+
+```js
+expect(new Date('2030-01-01'), 'not to be in the past');
+```
+
+### `{unknown} to be in the future`
+
+**Success**:
+
+```js
+expect(new Date('2030-01-01'), 'to be in the future');
+expect(new Date(Date.now() + 1000), 'to be in the future'); // 1 second from now
+expect('2030-12-31', 'to be in the future');
+```
+
+**Failure**:
+
+```js
+expect(new Date('2022-01-01'), 'to be in the future');
+// AssertionError: Expected 2022-01-01T00:00:00.000Z to be in the future
+```
+
+**Negation**:
+
+```js
+expect(new Date('2022-01-01'), 'not to be in the future');
+```
+
+### `{unknown} to be a weekend`
+
+**Success**:
+
+```js
+expect(new Date('2023-01-07'), 'to be a weekend'); // Saturday
+expect(new Date('2023-01-08'), 'to be a weekend'); // Sunday
+expect('2023-12-30', 'to be a weekend'); // Saturday
+```
+
+**Failure**:
+
+```js
+expect(new Date('2023-01-09'), 'to be a weekend'); // Monday
+// AssertionError: Expected 2023-01-09T00:00:00.000Z to be a weekend
+```
+
+**Negation**:
+
+```js
+expect(new Date('2023-01-09'), 'not to be a weekend'); // Monday
+```
+
+### `{unknown} to be a weekday`
+
+**Success**:
+
+```js
+expect(new Date('2023-01-09'), 'to be a weekday'); // Monday
+expect(new Date('2023-01-13'), 'to be a weekday'); // Friday
+expect('2023-01-10', 'to be a weekday'); // Tuesday
+```
+
+**Failure**:
+
+```js
+expect(new Date('2023-01-07'), 'to be a weekday'); // Saturday
+// AssertionError: Expected 2023-01-07T00:00:00.000Z to be a weekday
+```
+
+**Negation**:
+
+```js
+expect(new Date('2023-01-07'), 'not to be a weekday'); // Saturday
+```
+
+## Duration Formats
+
+The date/time assertions support human-readable duration strings in the following formats:
+
+- **Milliseconds**: `"100 milliseconds"`, `"500 ms"`
+- **Seconds**: `"30 seconds"`, `"1 second"`, `"45 sec"`
+- **Minutes**: `"5 minutes"`, `"1 minute"`, `"30 min"`
+- **Hours**: `"2 hours"`, `"1 hour"`, `"12 hr"`
+- **Days**: `"7 days"`, `"1 day"`
+- **Weeks**: `"2 weeks"`, `"1 week"`
+- **Months**: `"3 months"`, `"1 month"`
+- **Years**: `"2 years"`, `"1 year"`
+
+Examples:
+
+```js
+expect(someDate, 'to be within', '30 minutes ago');
+expect(futureDate, 'to be at least', '2 hours from now');
+expect(date1, 'to equal', date2, 'within', '1 second');
 ```

--- a/src/assertion/impl/index.ts
+++ b/src/assertion/impl/index.ts
@@ -14,6 +14,7 @@ export * from './async-parametric.js';
 export * from './async.js';
 export * from './sync-basic.js';
 export * from './sync-collection.js';
+export * from './sync-date.js';
 export * from './sync-esoteric.js';
 export * from './sync-parametric.js';
 export * from './sync.js';

--- a/src/assertion/impl/sync-date.ts
+++ b/src/assertion/impl/sync-date.ts
@@ -1,0 +1,640 @@
+/**
+ * Date and time-related assertions for temporal testing scenarios.
+ *
+ * This module provides comprehensive Date and Time assertions with natural
+ * language syntax for testing applications that deal with temporal data,
+ * scheduling, timestamps, and time-based operations.
+ *
+ * @packageDocumentation
+ * @groupDescription Date/Time Assertions
+ * Temporal assertions for dates, times, durations, and time-based comparisons.
+ *
+ * @showGroups
+ */
+
+import { z } from 'zod/v4';
+
+import { BupkisRegistry } from '../../metadata.js';
+import { createAssertion } from '../create.js';
+
+const { abs } = Math;
+const { now } = Date;
+
+/**
+ * Converts various date-like inputs to Date objects for comparison. Supports
+ * Date objects, ISO strings, and timestamps.
+ *
+ * @function
+ */
+const toDate = (value: unknown): Date | null => {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return isNaN(parsed.getTime()) ? null : parsed;
+  }
+  if (typeof value === 'number') {
+    const parsed = new Date(value);
+    return isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+};
+
+/**
+ * Parses a duration string like "1 hour", "30 minutes", "2 days" into
+ * milliseconds.
+ *
+ * @function
+ */
+const parseDuration = (duration: string): null | number => {
+  const match = duration
+    .trim()
+    .match(
+      /^(\d+)\s*(milliseconds?|ms|seconds?|s|minutes?|m|hours?|h|days?|d|weeks?|w|months?|months?|years?|y)$/i,
+    );
+  if (!match) {
+    return null;
+  }
+
+  const [, amountStr, unit] = match;
+  if (!amountStr || !unit) {
+    return null;
+  }
+  const amount = parseInt(amountStr, 10);
+
+  switch (unit.toLowerCase()) {
+    case 'd':
+      return amount * 24 * 60 * 60 * 1000;
+    case 'day':
+    case 'days':
+      return amount * 24 * 60 * 60 * 1000;
+    case 'h':
+      return amount * 60 * 60 * 1000;
+    case 'hour':
+    case 'hours':
+      return amount * 60 * 60 * 1000;
+    case 'm':
+      return amount * 60 * 1000;
+    case 'millisecond':
+    case 'milliseconds':
+    case 'ms':
+      return amount;
+    case 'minute':
+    case 'minutes':
+      return amount * 60 * 1000;
+    case 'month':
+    case 'months':
+      return amount * 30 * 24 * 60 * 60 * 1000; // Approximate
+    case 's':
+      return amount * 1000;
+    case 'second':
+    case 'seconds':
+      return amount * 1000;
+    case 'w':
+      return amount * 7 * 24 * 60 * 60 * 1000;
+    case 'week':
+    case 'weeks':
+      return amount * 7 * 24 * 60 * 60 * 1000;
+    case 'y':
+      return amount * 365 * 24 * 60 * 60 * 1000; // Approximate
+    case 'year':
+    case 'years':
+      return amount * 365 * 24 * 60 * 60 * 1000; // Approximate
+    default:
+      return null;
+  }
+};
+
+/**
+ * Schema for validating Date objects, ISO strings, or timestamps.
+ */
+const DateLikeSchema = z
+  .union([
+    z.date(),
+    z.string().refine((str) => !isNaN(new Date(str).getTime()), {
+      message: 'Invalid date string',
+    }),
+    z.number().refine((num) => !isNaN(new Date(num).getTime()), {
+      message: 'Invalid timestamp',
+    }),
+  ])
+  .register(BupkisRegistry, { name: 'date-like' })
+  .describe('Date, ISO string, or timestamp');
+
+/**
+ * Schema for validating duration strings.
+ */
+const DurationSchema = z
+  .string()
+  .refine((str) => parseDuration(str) !== null, {
+    message:
+      'Invalid duration format. Expected format: "1 hour", "30 minutes", "2 days", etc.',
+  })
+  .register(BupkisRegistry, { name: 'duration' })
+  .describe('Duration string like "1 hour", "30 minutes", "2 days"');
+
+/**
+ * Asserts that the subject is a valid date (Date object, ISO string, or
+ * timestamp).
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date(), 'to be a valid date'); // passes
+ * expect('2023-01-01T00:00:00Z', 'to be a valid date'); // passes
+ * expect(1640995200000, 'to be a valid date'); // passes
+ * expect('invalid', 'to be a valid date'); // fails
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const validDateAssertion = createAssertion(
+  [['to be a valid date', 'to be date-like']],
+  DateLikeSchema,
+  {
+    anchor: 'unknown-to-be-a-valid-date',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject represents today's date.
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date(), 'to be today'); // passes if run today
+ * expect(new Date('2022-01-01'), 'to be today'); // fails unless run on 2022-01-01
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const todayAssertion = createAssertion(
+  ['to be today'],
+  (subject) => {
+    const date = toDate(subject);
+    if (!date) {
+      return false;
+    }
+
+    const today = new Date();
+    return (
+      date.getFullYear() === today.getFullYear() &&
+      date.getMonth() === today.getMonth() &&
+      date.getDate() === today.getDate()
+    );
+  },
+  {
+    anchor: 'unknown-to-be-today',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is before another date.
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date('2022-01-01'), 'to be before', new Date('2023-01-01')); // passes
+ * expect(new Date('2023-01-01'), 'to be before', new Date('2022-01-01')); // fails
+ * expect('2022-01-01', 'to be before', '2023-01-01'); // passes
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const beforeAssertion = createAssertion(
+  [DateLikeSchema, 'to be before', DateLikeSchema],
+  (subject, other) => {
+    const subjectDate = toDate(subject);
+    const otherDate = toDate(other);
+    if (!subjectDate || !otherDate) {
+      return false;
+    }
+    return subjectDate.getTime() < otherDate.getTime();
+  },
+  {
+    anchor: 'date-like-to-be-before-date-like',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is after another date.
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date('2023-01-01'), 'to be after', new Date('2022-01-01')); // passes
+ * expect(new Date('2022-01-01'), 'to be after', new Date('2023-01-01')); // fails
+ * expect('2023-01-01', 'to be after', '2022-01-01'); // passes
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const afterAssertion = createAssertion(
+  [DateLikeSchema, 'to be after', DateLikeSchema],
+  (subject, other) => {
+    const subjectDate = toDate(subject);
+    const otherDate = toDate(other);
+    if (!subjectDate || !otherDate) {
+      return false;
+    }
+    return subjectDate.getTime() > otherDate.getTime();
+  },
+  {
+    anchor: 'date-like-to-be-after-date-like',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is between two dates (inclusive).
+ *
+ * @example
+ *
+ * ```ts
+ * expect(
+ *   new Date('2022-06-01'),
+ *   'to be between',
+ *   new Date('2022-01-01'),
+ *   new Date('2022-12-31'),
+ * ); // passes
+ * expect(
+ *   new Date('2023-01-01'),
+ *   'to be between',
+ *   new Date('2022-01-01'),
+ *   new Date('2022-12-31'),
+ * ); // fails
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const betweenAssertion = createAssertion(
+  [DateLikeSchema, 'to be between', DateLikeSchema, 'and', DateLikeSchema],
+  (subject, start, end) => {
+    const subjectDate = toDate(subject);
+    const startDate = toDate(start);
+    const endDate = toDate(end);
+    if (!subjectDate || !startDate || !endDate) {
+      return false;
+    }
+    const subjectTime = subjectDate.getTime();
+    return (
+      subjectTime >= startDate.getTime() && subjectTime <= endDate.getTime()
+    );
+  },
+  {
+    anchor: 'date-like-to-be-between-date-like-and-date-like',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is within a specific duration from now.
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date(), 'to be within', '1 hour from now'); // passes if within the last hour
+ * expect(
+ *   new Date(Date.now() - 3600000),
+ *   'to be within',
+ *   '30 minutes from now',
+ * ); // fails
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const withinFromNowAssertion = createAssertion(
+  [DateLikeSchema, 'to be within', DurationSchema, 'from now'],
+  (subject, durationStr) => {
+    const subjectDate = toDate(subject);
+    if (!subjectDate) {
+      return false;
+    }
+
+    const durationMs = parseDuration(durationStr);
+    if (durationMs === null) {
+      return false;
+    }
+
+    const nowTime = now();
+    const diff = abs(subjectDate.getTime() - nowTime);
+    return diff <= durationMs;
+  },
+  {
+    anchor: 'date-like-to-be-within-duration-from-now',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is within a specific duration ago from now.
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date(Date.now() - 1800000), 'to be within', '1 hour ago'); // passes if within 30 minutes ago
+ * expect(new Date(Date.now() + 1800000), 'to be within', '1 hour ago'); // fails (future date)
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const withinAgoAssertion = createAssertion(
+  [DateLikeSchema, 'to be within', DurationSchema, 'ago'],
+  (subject, durationStr) => {
+    const subjectDate = toDate(subject);
+    if (!subjectDate) {
+      return false;
+    }
+
+    const durationMs = parseDuration(durationStr);
+    if (durationMs === null) {
+      return false;
+    }
+
+    const nowTime = now();
+    const subjectTime = subjectDate.getTime();
+
+    // Must be in the past and within the duration
+    return subjectTime <= nowTime && nowTime - subjectTime <= durationMs;
+  },
+  {
+    anchor: 'date-like-to-be-within-duration-ago',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is at least a specific duration from now (future).
+ *
+ * @example
+ *
+ * ```ts
+ * expect(
+ *   new Date(Date.now() + 7200000),
+ *   'to be at least',
+ *   '1 hour from now',
+ * ); // passes (2 hours from now)
+ * expect(
+ *   new Date(Date.now() + 1800000),
+ *   'to be at least',
+ *   '1 hour from now',
+ * ); // fails (30 minutes from now)
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const atLeastFromNowAssertion = createAssertion(
+  [DateLikeSchema, 'to be at least', DurationSchema, 'from now'],
+  (subject, durationStr) => {
+    const subjectDate = toDate(subject);
+    if (!subjectDate) {
+      return false;
+    }
+
+    const durationMs = parseDuration(durationStr);
+    if (durationMs === null) {
+      return false;
+    }
+
+    const nowTime = now();
+    const subjectTime = subjectDate.getTime();
+
+    // Must be in the future and at least the duration away
+    return subjectTime > nowTime && subjectTime - nowTime >= durationMs;
+  },
+  {
+    anchor: 'date-like-to-be-at-least-duration-from-now',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is at least a specific duration ago.
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date(Date.now() - 7200000), 'to be at least', '1 hour ago'); // passes (2 hours ago)
+ * expect(new Date(Date.now() - 1800000), 'to be at least', '1 hour ago'); // fails (30 minutes ago)
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const atLeastAgoAssertion = createAssertion(
+  [DateLikeSchema, 'to be at least', DurationSchema, 'ago'],
+  (subject, durationStr) => {
+    const subjectDate = toDate(subject);
+    if (!subjectDate) {
+      return false;
+    }
+
+    const durationMs = parseDuration(durationStr);
+    if (durationMs === null) {
+      return false;
+    }
+
+    const nowTime = now();
+    const subjectTime = subjectDate.getTime();
+
+    // Must be in the past and at least the duration ago
+    return subjectTime <= nowTime && nowTime - subjectTime >= durationMs;
+  },
+  {
+    anchor: 'date-like-to-be-at-least-duration-ago',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is the same date as another (ignoring time).
+ *
+ * @example
+ *
+ * ```ts
+ * expect(
+ *   new Date('2023-01-01T10:00:00'),
+ *   'to be the same date as',
+ *   new Date('2023-01-01T15:30:00'),
+ * ); // passes
+ * expect(
+ *   new Date('2023-01-01'),
+ *   'to be the same date as',
+ *   new Date('2023-01-02'),
+ * ); // fails
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const sameDateAssertion = createAssertion(
+  [DateLikeSchema, 'to be the same date as', DateLikeSchema],
+  (subject, other) => {
+    const subjectDate = toDate(subject);
+    const otherDate = toDate(other);
+    if (!subjectDate || !otherDate) {
+      return false;
+    }
+
+    return (
+      subjectDate.getFullYear() === otherDate.getFullYear() &&
+      subjectDate.getMonth() === otherDate.getMonth() &&
+      subjectDate.getDate() === otherDate.getDate()
+    );
+  },
+  {
+    anchor: 'date-like-to-be-the-same-date-as-date-like',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is equal to another date within a tolerance.
+ *
+ * @example
+ *
+ * ```ts
+ * const date1 = new Date('2023-01-01T10:00:00.000Z');
+ * const date2 = new Date('2023-01-01T10:00:00.500Z');
+ * expect(date1, 'to equal', date2, 'within', '1 second'); // passes
+ * expect(date1, 'to equal', date2, 'within', '100 milliseconds'); // fails
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const equalWithinAssertion = createAssertion(
+  [DateLikeSchema, 'to equal', DateLikeSchema, 'within', DurationSchema],
+  (subject, other, toleranceStr) => {
+    const subjectDate = toDate(subject);
+    const otherDate = toDate(other);
+    if (!subjectDate || !otherDate) {
+      return false;
+    }
+
+    const toleranceMs = parseDuration(toleranceStr);
+    if (toleranceMs === null) {
+      return false;
+    }
+
+    const diff = abs(subjectDate.getTime() - otherDate.getTime());
+    return diff <= toleranceMs;
+  },
+  {
+    anchor: 'date-like-to-equal-date-like-within-duration',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is in the past.
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date('2022-01-01'), 'to be in the past'); // passes
+ * expect(new Date('2030-01-01'), 'to be in the past'); // fails
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const inThePastAssertion = createAssertion(
+  ['to be in the past'],
+  (subject) => {
+    const date = toDate(subject);
+    if (!date) {
+      return false;
+    }
+    return date.getTime() < now();
+  },
+  {
+    anchor: 'unknown-to-be-in-the-past',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is in the future.
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date('2030-01-01'), 'to be in the future'); // passes
+ * expect(new Date('2022-01-01'), 'to be in the future'); // fails
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const inTheFutureAssertion = createAssertion(
+  ['to be in the future'],
+  (subject) => {
+    const date = toDate(subject);
+    if (!date) {
+      return false;
+    }
+    return date.getTime() > now();
+  },
+  {
+    anchor: 'unknown-to-be-in-the-future',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is a weekend (Saturday or Sunday).
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date('2023-01-07'), 'to be a weekend'); // passes (Saturday)
+ * expect(new Date('2023-01-08'), 'to be a weekend'); // passes (Sunday)
+ * expect(new Date('2023-01-09'), 'to be a weekend'); // fails (Monday)
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const weekendAssertion = createAssertion(
+  ['to be a weekend'],
+  (subject) => {
+    const date = toDate(subject);
+    if (!date) {
+      return false;
+    }
+    const day = date.getDay();
+    return day === 0 || day === 6; // Sunday or Saturday
+  },
+  {
+    anchor: 'unknown-to-be-a-weekend',
+    category: 'date',
+  },
+);
+
+/**
+ * Asserts that the subject is a weekday (Monday through Friday).
+ *
+ * @example
+ *
+ * ```ts
+ * expect(new Date('2023-01-09'), 'to be a weekday'); // passes (Monday)
+ * expect(new Date('2023-01-13'), 'to be a weekday'); // passes (Friday)
+ * expect(new Date('2023-01-07'), 'to be a weekday'); // fails (Saturday)
+ * ```
+ *
+ * @group Date/Time Assertions
+ */
+export const weekdayAssertion = createAssertion(
+  ['to be a weekday'],
+  (subject) => {
+    const date = toDate(subject);
+    if (!date) {
+      return false;
+    }
+    const day = date.getDay();
+    return day >= 1 && day <= 5; // Monday through Friday
+  },
+  {
+    anchor: 'unknown-to-be-a-weekday',
+    category: 'date',
+  },
+);

--- a/src/assertion/impl/sync.ts
+++ b/src/assertion/impl/sync.ts
@@ -86,6 +86,23 @@ import {
   setUnionEqualityAssertion,
 } from './sync-collection.js';
 import {
+  afterAssertion,
+  atLeastAgoAssertion,
+  atLeastFromNowAssertion,
+  beforeAssertion,
+  betweenAssertion,
+  equalWithinAssertion,
+  inTheFutureAssertion,
+  inThePastAssertion,
+  sameDateAssertion,
+  todayAssertion,
+  validDateAssertion,
+  weekdayAssertion,
+  weekendAssertion,
+  withinAgoAssertion,
+  withinFromNowAssertion,
+} from './sync-date.js';
+import {
   enumerablePropertyAssertion,
   enumerablePropertyAssertion2,
   extensibleAssertion,
@@ -124,6 +141,24 @@ import {
   stringMatchesAssertion,
   typeOfAssertion,
 } from './sync-parametric.js';
+
+export const SyncDateAssertions = [
+  afterAssertion,
+  atLeastAgoAssertion,
+  atLeastFromNowAssertion,
+  beforeAssertion,
+  betweenAssertion,
+  equalWithinAssertion,
+  inTheFutureAssertion,
+  inThePastAssertion,
+  sameDateAssertion,
+  todayAssertion,
+  validDateAssertion,
+  weekdayAssertion,
+  weekendAssertion,
+  withinAgoAssertion,
+  withinFromNowAssertion,
+] as const;
 
 /**
  * Tuple of all built-in esoteric synchronous assertions.
@@ -269,11 +304,13 @@ export const SyncAssertions = [
   ...SyncBasicAssertions,
   ...SyncParametricAssertions,
   ...SyncEsotericAssertions,
+  ...SyncDateAssertions,
 ] as const;
 
 // Re-export collection tuples for compatibility
 // Re-export all individual assertions for convenience
 export * from './sync-basic.js';
 export * from './sync-collection.js';
+export * from './sync-date.js';
 export * from './sync-esoteric.js';
 export * from './sync-parametric.js';

--- a/src/assertion/slotify.ts
+++ b/src/assertion/slotify.ts
@@ -62,7 +62,7 @@ export const slotify = <const Parts extends AssertionParts>(
     } else if (isPhraseLiteral(part)) {
       if (part.startsWith('not ')) {
         throw new AssertionImplementationError(
-          `PhraseLiteral at parts[${index}] must not start with "not ": ${inspect(
+          `PhraseLiteral at parts[${index}] must not start with "not "; refactor to be a positive assertion: ${inspect(
             part,
           )}`,
         );

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -20,6 +20,7 @@ import { type z } from 'zod/v4';
 
 import type { PhraseLiteralChoice } from './assertion/assertion-types.js';
 import type {
+  AssertionPart,
   Constructor,
   ExpectItExecutor,
   PhraseLiteral,
@@ -207,7 +208,7 @@ export const isWeakKey = (value: unknown): value is WeakKey =>
  * @internal
  */
 export const isPhraseLiteralChoice = (
-  value: unknown,
+  value: AssertionPart,
 ): value is PhraseLiteralChoice =>
   isArray(value) && value.length >= 1 && value.every(isPhraseLiteral);
 
@@ -220,7 +221,7 @@ export const isPhraseLiteralChoice = (
  * @returns `true` if the part is a `PhraseLiteral`, `false` otherwise
  * @internal
  */
-export const isPhraseLiteral = (value: unknown): value is PhraseLiteral =>
+export const isPhraseLiteral = (value: AssertionPart): value is PhraseLiteral =>
   isString(value) && value !== 'and';
 
 /**
@@ -232,7 +233,7 @@ export const isPhraseLiteral = (value: unknown): value is PhraseLiteral =>
  *   `false` otherwise
  */
 export const isPhrase = (
-  value: unknown,
+  value: AssertionPart,
 ): value is PhraseLiteral | PhraseLiteralChoice =>
   isPhraseLiteral(value) || isPhraseLiteralChoice(value);
 

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -18,12 +18,8 @@
 
 import { type z } from 'zod/v4';
 
+import type { PhraseLiteralChoice } from './assertion/assertion-types.js';
 import type {
-  AssertionPart,
-  PhraseLiteralChoice,
-} from './assertion/assertion-types.js';
-import type {
-  AssertionParts,
   Constructor,
   ExpectItExecutor,
   PhraseLiteral,
@@ -329,27 +325,3 @@ export const isExpectItExecutor = <Subject extends z.ZodType = z.ZodUnknown>(
 ): value is ExpectItExecutor<Subject> => {
   return isFunction(value) && kExpectIt in value && value[kExpectIt] === true;
 };
-
-/**
- * Type guard for an {@link AssertionPart}, which can be a {@link PhraseLiteral},
- * {@link PhraseLiteralChoice}, or a Zod schema.
- *
- * @function
- * @param value Value to check
- * @returns `true` if the value is an `AssertionPart`, `false` otherwise
- * @internal
- */
-export const isAssertionPart = (value: unknown): value is AssertionPart =>
-  isPhraseLiteral(value) || isPhraseLiteralChoice(value) || isZodType(value);
-
-/**
- * Type guard for {@link AssertionParts}, which is an array of
- * {@link AssertionPart}.
- *
- * @function
- * @param value Value to check
- * @returns `true` if the value is an `AssertionParts`, `false` otherwise
- * @internal
- */
-export const isAssertionParts = (value: unknown): value is AssertionParts =>
-  isArray(value) && !!value.length && value.every(isAssertionPart);

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -213,7 +213,7 @@ export const isWeakKey = (value: unknown): value is WeakKey =>
 export const isPhraseLiteralChoice = (
   value: unknown,
 ): value is PhraseLiteralChoice =>
-  isArray(value) && value.every(isPhraseLiteral);
+  isArray(value) && value.length >= 1 && value.every(isPhraseLiteral);
 
 /**
  * Type guard for a {@link PhraseLiteral}, which is just a string that does not
@@ -225,7 +225,7 @@ export const isPhraseLiteralChoice = (
  * @internal
  */
 export const isPhraseLiteral = (value: unknown): value is PhraseLiteral =>
-  isString(value) && !value.startsWith('not ') && value !== 'and';
+  isString(value) && value !== 'and';
 
 /**
  * Type guard for a {@link PhraseLiteral} or {@link PhraseLiteralChoice}.

--- a/test/core/expect.test.ts
+++ b/test/core/expect.test.ts
@@ -415,6 +415,43 @@ describe('core API', () => {
           );
         });
       });
+
+      describe('when an assertion has a bare "and" in its parts', () => {
+        it('should not throw UnknownAssertionError', () => {
+          expect(
+            () =>
+              expect(
+                Date.now(),
+                'to be between',
+                Date.now() - 1000,
+                'and',
+                Date.now() + 1000,
+                'and',
+                'to be an integer',
+              ),
+            'not to throw',
+          );
+        });
+
+        it('should throw an AssertionError', () => {
+          expect(
+            () =>
+              expect(
+                new Date(Date.now()),
+                'to be between',
+                new Date(Date.now() - 1000),
+                'and',
+                new Date(Date.now() + 1000),
+                'and',
+                'to be a string',
+              ),
+            'to throw an',
+            AssertionError,
+            'satisfying',
+            /Comparing two different types of values/,
+          );
+        });
+      });
     });
 
     describe('Schema-based async assertions', () => {

--- a/test/core/slotify.test.ts
+++ b/test/core/slotify.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+
+import { slotify } from '../../src/assertion/slotify.js';
+import { expect } from '../custom-assertions.js';
+
+/**
+ * `slotify()` converts {@link bupkis!types.AssertionParts | AssertionParts} into
+ * {@link bupkis!types.AssertionSlots | AssertionSlots} by processing string
+ * literals and Zod schemas, registering metadata for runtime introspection, and
+ * handling validation constraints such as preventing "not " prefixes in string
+ * literal parts.
+ */
+describe('slotify()', () => {
+  describe('error handling', () => {
+    describe('when the AssertionParts contain a phrase literal beginning with "not "', () => {
+      it('should throw', () => {
+        const parts = ['not to be a foo'] as const;
+        expect(() => slotify(parts), 'to throw', {
+          code: 'ERR_BUPKIS_ASSERTION_IMPL',
+          message: /must not start with "not "/,
+        });
+      });
+    });
+
+    describe('when the AssertionParts contain a phrase literal choice beginning with "not "', () => {
+      it('should throw', () => {
+        const parts = [['stuff', 'not to be a foo']] as const;
+        expect(() => slotify(parts), 'to throw', {
+          code: 'ERR_BUPKIS_ASSERTION_IMPL',
+          message: /must not include phrases starting with "not "/,
+        });
+      });
+    });
+
+    describe('when the AssertionParts contain a phrase literal "and" not followed by a Zod schema', () => {
+      it('should throw', () => {
+        const parts = ['to be a foo', 'and', 'to be a bar'] as const;
+        expect(() => slotify(parts), 'to throw', {
+          code: 'ERR_BUPKIS_ASSERTION_IMPL',
+          message: /must be followed by a Zod schema/,
+        });
+      });
+
+      describe('when "and" is the last part', () => {
+        it('should throw', () => {
+          const parts = ['to be a foo', 'and'] as const;
+          expect(() => slotify(parts), 'to throw', {
+            code: 'ERR_BUPKIS_ASSERTION_IMPL',
+            message: /must be followed by a Zod schema/,
+          });
+        });
+      });
+    });
+
+    describe('when an invalid AssertionPart is provided', () => {
+      it('should throw', () => {
+        const parts = ['to be a foo', 42, 'to be a bar'] as const;
+        // @ts-expect-error testing invalid input
+        expect(() => slotify(parts), 'to throw', {
+          code: 'ERR_BUPKIS_ASSERTION_IMPL',
+          message:
+            /Expected Zod schema, phrase literal, or phrase literal choice/,
+        });
+      });
+    });
+  });
+});

--- a/test/property/sync-date.test.ts
+++ b/test/property/sync-date.test.ts
@@ -1,0 +1,661 @@
+import fc from 'fast-check';
+import { describe, it } from 'node:test';
+
+import type { AnyAssertion } from '../../src/types.js';
+
+import * as assertions from '../../src/assertion/impl/sync-date.js';
+import { expect } from '../custom-assertions.js';
+import {
+  type PropertyTestConfig,
+  type PropertyTestConfigParameters,
+} from './property-test-config.js';
+import {
+  extractPhrases,
+  filteredAnything,
+  getVariants,
+  runVariant,
+} from './property-test-util.js';
+
+// Get all the sync date assertions
+const allAssertions = Object.values(assertions);
+
+/**
+ * Test config defaults
+ */
+const testConfigDefaults: PropertyTestConfigParameters = {} as const;
+
+/**
+ * Generates valid date-like values (Date objects, ISO strings, timestamps)
+ */
+const validDateLikeGenerator = fc
+  .oneof(
+    fc.date({
+      max: new Date('2100-01-01'),
+      min: new Date(0),
+      noInvalidDate: true,
+    }),
+    fc
+      .date({
+        max: new Date('2100-01-01'),
+        min: new Date(0),
+        noInvalidDate: true,
+      })
+      .map((d) => d.toISOString()),
+    fc
+      .date({
+        max: new Date('2100-01-01'),
+        min: new Date(0),
+        noInvalidDate: true,
+      })
+      .map((d) => d.getTime()),
+  )
+  .filter((v) => `${new Date(v)}` !== 'Invalid Date');
+
+/**
+ * Generates invalid date-like values
+ */
+const invalidDateLikeGenerator = filteredAnything.filter(
+  (v) =>
+    !(v instanceof Date) &&
+    (typeof v !== 'string' || Number.isNaN(new Date(v).getTime())) &&
+    (typeof v !== 'number' || Number.isNaN(new Date(v).getTime())),
+);
+
+/**
+ * Generates valid duration strings
+ */
+const validDurationGenerator = fc.oneof(
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} milliseconds`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} ms`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} seconds`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} s`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} minutes`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} m`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} hours`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} h`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} days`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} d`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} weeks`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} w`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} months`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} years`),
+  fc.integer({ max: 100, min: 1 }).map((n) => `${n} y`),
+);
+
+/**
+ * Generates dates that are known to be today (for testing)
+ */
+const todayDateGenerator = fc.constant(new Date());
+
+/**
+ * Generates dates that are not today
+ */
+const notTodayDateGenerator = fc.oneof(
+  fc.date({ noInvalidDate: true }).filter((d) => {
+    const today = new Date();
+    return !(
+      d.getFullYear() === today.getFullYear() &&
+      d.getMonth() === today.getMonth() &&
+      d.getDate() === today.getDate()
+    );
+  }),
+  fc.constant(new Date('2020-01-01')),
+  fc.constant(new Date('2030-12-31')),
+);
+
+/**
+ * Generates past dates
+ */
+const pastDateGenerator = fc.date({
+  max: new Date(Date.now() - 5000), // At least 5 seconds ago to avoid timing issues
+  noInvalidDate: true,
+});
+
+/**
+ * Generates future dates
+ */
+const futureDateGenerator = fc.date({
+  min: new Date(Date.now() + 5000), // At least 5 seconds from now to avoid timing issues
+  noInvalidDate: true,
+});
+
+/**
+ * Generates weekend dates (Saturday or Sunday)
+ */
+const weekendDateGenerator = fc.date({ noInvalidDate: true }).filter((d) => {
+  const day = d.getDay();
+  return day === 0 || day === 6; // Sunday or Saturday
+});
+
+/**
+ * Generates weekday dates (Monday through Friday)
+ */
+const weekdayDateGenerator = fc.date({ noInvalidDate: true }).filter((d) => {
+  const day = d.getDay();
+  return day >= 1 && day <= 5; // Monday through Friday
+});
+
+/**
+ * Map of assertions to their property test configurations.
+ */
+const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
+  [
+    assertions.afterAssertion,
+    {
+      invalid: {
+        generators: fc
+          .tuple(validDateLikeGenerator, validDateLikeGenerator)
+          .filter(([a, b]) => {
+            const dateA = new Date(a);
+            const dateB = new Date(b);
+            return dateA.getTime() <= dateB.getTime();
+          })
+          .map(([subject, other]) => [subject, 'to be after', other]),
+      },
+      valid: {
+        generators: fc
+          .tuple(validDateLikeGenerator, validDateLikeGenerator)
+          .filter(([a, b]) => {
+            const dateA = new Date(a);
+            const dateB = new Date(b);
+            return dateA.getTime() > dateB.getTime();
+          })
+          .map(([subject, other]) => [subject, 'to be after', other]),
+      },
+    },
+  ],
+
+  [
+    assertions.atLeastAgoAssertion,
+    {
+      invalid: {
+        generators: fc
+          .oneof(
+            // Future dates should fail
+            fc.tuple(futureDateGenerator, validDurationGenerator),
+            // Dates too close to now should fail
+            fc.tuple(
+              fc.date({
+                max: new Date(Date.now() - 1000), // 1 second ago
+                min: new Date(Date.now() - 1800000), // 30 minutes ago
+                noInvalidDate: true,
+              }),
+              fc.constant('1 hour'),
+            ),
+          )
+          .map(([date, duration]) => [date, 'to be at least', duration, 'ago']),
+      },
+      valid: {
+        generators: fc
+          .tuple(
+            fc.date({
+              max: new Date(Date.now() - 7200000), // 2 hours ago
+              min: new Date(Date.now() - 86400000), // 1 day ago
+              noInvalidDate: true,
+            }),
+            fc.constant('1 hour'),
+          )
+          .map(([date, duration]) => [date, 'to be at least', duration, 'ago']),
+      },
+    },
+  ],
+
+  [
+    assertions.atLeastFromNowAssertion,
+    {
+      invalid: {
+        generators: fc
+          .oneof(
+            // Past dates should fail
+            fc.tuple(pastDateGenerator, validDurationGenerator),
+            // Dates too close to now should fail
+            fc.tuple(
+              fc.date({
+                max: new Date(Date.now() + 1800000), // 30 minutes from now
+                min: new Date(Date.now() + 1000), // 1 second from now
+                noInvalidDate: true,
+              }),
+              fc.constant('1 hour'),
+            ),
+          )
+          .map(([date, duration]) => [
+            date,
+            'to be at least',
+            duration,
+            'from now',
+          ]),
+      },
+      valid: {
+        generators: fc
+          .tuple(
+            fc.date({
+              max: new Date(Date.now() + 86400000), // 1 day from now
+              min: new Date(Date.now() + 7200000), // 2 hours from now
+              noInvalidDate: true,
+            }),
+            fc.constant('1 hour'),
+          )
+          .map(([date, duration]) => [
+            date,
+            'to be at least',
+            duration,
+            'from now',
+          ]),
+      },
+    },
+  ],
+
+  [
+    assertions.beforeAssertion,
+    {
+      invalid: {
+        generators: fc
+          .tuple(validDateLikeGenerator, validDateLikeGenerator)
+          .filter(([a, b]) => {
+            const dateA = new Date(a);
+            const dateB = new Date(b);
+            // Ensure both dates are valid
+            if (isNaN(dateA.getTime()) || isNaN(dateB.getTime())) {
+              return false;
+            }
+            return dateA.getTime() >= dateB.getTime();
+          })
+          .map(([subject, other]) => [subject, 'to be before', other]),
+      },
+      valid: {
+        generators: fc
+          .tuple(validDateLikeGenerator, validDateLikeGenerator)
+          .filter(([a, b]) => {
+            const dateA = new Date(a);
+            const dateB = new Date(b);
+            // Ensure both dates are valid
+            if (isNaN(dateA.getTime()) || isNaN(dateB.getTime())) {
+              return false;
+            }
+            return dateA.getTime() < dateB.getTime();
+          })
+          .map(([subject, other]) => [subject, 'to be before', other]),
+      },
+    },
+  ],
+
+  [
+    assertions.betweenAssertion,
+    {
+      invalid: {
+        generators: fc
+          .tuple(
+            validDateLikeGenerator,
+            fc.integer({ max: 100000, min: 1 }),
+            fc.integer({ max: 100000, min: 1 }),
+          )
+          .chain(([subject, offset1, offset2]) =>
+            fc.oneof(
+              fc.tuple(
+                fc.constant(subject),
+                fc.date({
+                  min: new Date(new Date(subject).getTime() + offset1),
+                  noInvalidDate: true,
+                }),
+                fc.date({
+                  min: new Date(new Date(subject).getTime() + offset2),
+                  noInvalidDate: true,
+                }),
+              ),
+              fc.tuple(
+                fc.constant(subject),
+                fc.date({
+                  max: new Date(new Date(subject).getTime() - offset1),
+                  noInvalidDate: true,
+                }),
+                fc.date({
+                  max: new Date(new Date(subject).getTime() - offset2),
+                  noInvalidDate: true,
+                }),
+              ),
+            ),
+          )
+          .map(([subject, start, end]) => [
+            subject,
+            'to be between',
+            start,
+            'and',
+            end,
+          ]),
+      },
+      valid: {
+        generators: validDateLikeGenerator
+          .chain((subject) =>
+            fc.tuple(
+              fc.constant(subject),
+              fc.date({
+                max: new Date(subject),
+                min: new Date(0),
+                noInvalidDate: true,
+              }),
+              fc.date({
+                max: new Date('2100-01-01'),
+                min: new Date(subject),
+                noInvalidDate: true,
+              }),
+            ),
+          )
+          .map(([subject, start, end]) => [
+            subject,
+            'to be between',
+            start,
+            'and',
+            end,
+          ]),
+      },
+    },
+  ],
+
+  [
+    assertions.equalWithinAssertion,
+    {
+      invalid: {
+        generators: fc
+          .tuple(
+            fc.date({
+              max: new Date('2100-01-01'),
+              min: new Date('2000-01-01'),
+              noInvalidDate: true,
+            }),
+            fc.date({
+              max: new Date('2100-01-01'),
+              min: new Date('2000-01-01'),
+              noInvalidDate: true,
+            }),
+          )
+          .filter(([a, b]) => {
+            // Ensure both dates are valid and significantly apart
+            return (
+              !Number.isNaN(a.getTime()) &&
+              !Number.isNaN(b.getTime()) &&
+              Math.abs(a.getTime() - b.getTime()) > 2000
+            );
+          })
+          .map(([subject, other]) => [
+            subject,
+            'to equal',
+            other,
+            'within',
+            '1 second',
+          ]),
+      },
+      valid: {
+        generators: fc
+          .date({
+            max: new Date('2099-01-01'), // Ensure room for addition
+            min: new Date('2000-01-01'),
+            noInvalidDate: true,
+          })
+          .filter((date) => !Number.isNaN(date.getTime())) // Ensure valid date
+          .map((baseDate) => {
+            const offset = Math.floor(Math.random() * 500); // Within 500ms
+            const closeDate = new Date(baseDate.getTime() + offset);
+            // Ensure the new date is also valid
+            if (isNaN(closeDate.getTime())) {
+              return [baseDate, 'to equal', baseDate, 'within', '1 second'];
+            }
+            return [baseDate, 'to equal', closeDate, 'within', '1 second'];
+          }),
+      },
+    },
+  ],
+
+  [
+    assertions.inTheFutureAssertion,
+    {
+      invalid: {
+        generators: [
+          pastDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.inTheFutureAssertion)),
+        ],
+      },
+      valid: {
+        generators: [
+          futureDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.inTheFutureAssertion)),
+        ],
+      },
+    },
+  ],
+
+  [
+    assertions.inThePastAssertion,
+    {
+      invalid: {
+        generators: [
+          futureDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.inThePastAssertion)),
+        ],
+      },
+      valid: {
+        generators: [
+          pastDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.inThePastAssertion)),
+        ],
+      },
+    },
+  ],
+
+  [
+    assertions.sameDateAssertion,
+    {
+      invalid: {
+        generators: fc
+          .tuple(validDateLikeGenerator, validDateLikeGenerator)
+          .filter(([a, b]) => {
+            const dateA = new Date(a);
+            const dateB = new Date(b);
+            return !(
+              dateA.getFullYear() === dateB.getFullYear() &&
+              dateA.getMonth() === dateB.getMonth() &&
+              dateA.getDate() === dateB.getDate()
+            );
+          })
+          .map(([subject, other]) => [
+            subject,
+            'to be the same date as',
+            other,
+          ]),
+      },
+      valid: {
+        generators: fc
+          .date({ noInvalidDate: true })
+          .chain((baseDate) => {
+            const sameDate = new Date(baseDate);
+            return fc.tuple(fc.constant(baseDate), fc.constant(sameDate));
+          })
+          .map(([subject, other]) => [
+            subject,
+            'to be the same date as',
+            other,
+          ]),
+      },
+    },
+  ],
+
+  [
+    assertions.todayAssertion,
+    {
+      invalid: {
+        generators: [
+          notTodayDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.todayAssertion)),
+        ],
+      },
+      valid: {
+        generators: [
+          todayDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.todayAssertion)),
+        ],
+      },
+    },
+  ],
+
+  [
+    assertions.validDateAssertion,
+    {
+      invalid: {
+        generators: [
+          invalidDateLikeGenerator,
+          fc.constantFrom(...extractPhrases(assertions.validDateAssertion)),
+        ],
+      },
+      valid: {
+        generators: [
+          validDateLikeGenerator,
+          fc.constantFrom(...extractPhrases(assertions.validDateAssertion)),
+        ],
+      },
+    },
+  ],
+
+  [
+    assertions.weekdayAssertion,
+    {
+      invalid: {
+        generators: [
+          weekendDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.weekdayAssertion)),
+        ],
+      },
+      valid: {
+        generators: [
+          weekdayDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.weekdayAssertion)),
+        ],
+      },
+    },
+  ],
+
+  [
+    assertions.weekendAssertion,
+    {
+      invalid: {
+        generators: [
+          weekdayDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.weekendAssertion)),
+        ],
+      },
+      valid: {
+        generators: [
+          weekendDateGenerator,
+          fc.constantFrom(...extractPhrases(assertions.weekendAssertion)),
+        ],
+      },
+    },
+  ],
+
+  [
+    assertions.withinAgoAssertion,
+    {
+      invalid: {
+        generators: fc
+          .oneof(
+            // Future dates should fail
+            fc.tuple(
+              fc.date({
+                min: new Date(Date.now() + 10000), // At least 10 seconds in future
+                noInvalidDate: true,
+              }),
+              fc.constant('1 hour'),
+            ),
+            // Dates too far in the past should fail
+            fc.tuple(
+              fc.date({
+                max: new Date(Date.now() - 7200000), // More than 2 hours ago
+                noInvalidDate: true,
+              }),
+              fc.constant('1 hour'), // Only 1 hour tolerance
+            ),
+          )
+          .map(([date, duration]) => [date, 'to be within', duration, 'ago']),
+      },
+      valid: {
+        generators: fc
+          .tuple(
+            fc.date({
+              max: new Date(Date.now() - 10000), // At least 10 seconds ago
+              min: new Date(Date.now() - 1800000), // 30 minutes ago
+              noInvalidDate: true,
+            }),
+            fc.constant('1 hour'),
+          )
+          .map(([date, duration]) => [date, 'to be within', duration, 'ago']),
+      },
+    },
+  ],
+
+  [
+    assertions.withinFromNowAssertion,
+    {
+      invalid: {
+        generators: fc
+          .tuple(
+            fc
+              .date({ noInvalidDate: true })
+              .filter((d) => Math.abs(d.getTime() - Date.now()) > 7200000), // More than 2 hours difference
+            fc.constant('1 hour'),
+          )
+          .map(([date, duration]) => [
+            date,
+            'to be within',
+            duration,
+            'from now',
+          ]),
+      },
+      valid: {
+        generators: fc
+          .tuple(
+            fc.date({
+              max: new Date(Date.now() + 1800000), // 30 minutes from now
+              min: new Date(Date.now() - 1800000), // 30 minutes ago
+              noInvalidDate: true,
+            }),
+            fc.constant('1 hour'),
+          )
+          .map(([date, duration]) => [
+            date,
+            'to be within',
+            duration,
+            'from now',
+          ]),
+      },
+    },
+  ],
+]);
+
+describe('Date/Time assertions property tests', () => {
+  for (const [assertion, testConfig] of testConfigs) {
+    const { id } = assertion;
+
+    describe(`Assertion: ${assertion} [${id}]`, () => {
+      const runVariants = (configs: PropertyTestConfig[]) => {
+        for (const config of configs) {
+          const { params, variants } = getVariants(config);
+          for (const [name, variant] of variants) {
+            it(`should pass ${name} checks [${id}]`, async () => {
+              await runVariant(variant, testConfigDefaults, params, name);
+            });
+          }
+        }
+      };
+
+      runVariants(Array.isArray(testConfig) ? testConfig : [testConfig]);
+    });
+  }
+
+  it('should exhaustively test collection SyncDateAssertions', () => {
+    expect(
+      testConfigs,
+      'to exhaustively test collection',
+      'SyncDateAssertions',
+      'from',
+      allAssertions,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #29

chore(tests): added some error-handling tests for slotify

loosened the type guards for phrase literals

chore(guards): remove unused type guards

chore(guards): phrase-related guards only accept AssertionPart types

fix(expect): proper handling of assertions containing bare "and" phrases

feat(assertions): add more date assertions