### PR TITLE
fix(assertions): conjunction fixes again

### DIFF
--- a/.wallaby.js
+++ b/.wallaby.js
@@ -20,7 +20,7 @@ export default {
     '!src/node_modules/bupkis/**',
     { instrument: false, pattern: 'test/**/*.test.ts.snapshot' },
   ],
-  filesWithNoCoverageCalculated: ['.tmp/**/*.test.ts'],
+  filesWithNoCoverageCalculated: ['.tmp/**/*.test.ts', 'test/**/*.ts'],
   preloadModules: ['tsx/esm'],
   runMode: 'onsave',
   tests: [

--- a/src/assertion/assertion-async.ts
+++ b/src/assertion/assertion-async.ts
@@ -144,6 +144,7 @@ export class BupkisAssertionFunctionAsync<
     } else if (isBoolean(result)) {
       if (!result) {
         throw new AssertionError({
+          id: this.id,
           message: `Assertion ${this} failed for arguments: ${inspect(args)}`,
         });
       }
@@ -164,6 +165,7 @@ export class BupkisAssertionFunctionAsync<
       throw new AssertionError({
         actual: result.actual,
         expected: result.expected,
+        id: this.id,
         message:
           result.message ??
           `Assertion ${this} failed for arguments: ${inspect(args)}`,

--- a/src/assertion/assertion-sync.ts
+++ b/src/assertion/assertion-sync.ts
@@ -181,6 +181,7 @@ export class BupkisAssertionFunctionSync<
     } else if (isBoolean(result)) {
       if (!result) {
         throw new AssertionError({
+          id: this.id,
           message: `Assertion ${this} failed for arguments: ${inspect(args)}`,
         });
       }
@@ -201,6 +202,7 @@ export class BupkisAssertionFunctionSync<
       throw new AssertionError({
         actual: result.actual,
         expected: result.expected,
+        id: this.id,
         message:
           result.message ??
           `Assertion ${this} failed for arguments: ${inspect(args)}`,

--- a/src/assertion/assertion.ts
+++ b/src/assertion/assertion.ts
@@ -233,6 +233,7 @@ export abstract class BupkisAssertion<
       return new AssertionError({
         actual,
         expected,
+        id: this.id,
         message,
         stackStartFn,
       });
@@ -241,6 +242,7 @@ export abstract class BupkisAssertion<
       const pretty = z.prettifyError(zodError).slice(2);
       return new AssertionError({
         actual: subject,
+        id: this.id,
         message: `Assertion ${this} failed:\n${pretty}`,
         stackStartFn,
       });

--- a/src/assertion/impl/sync-collection.ts
+++ b/src/assertion/impl/sync-collection.ts
@@ -20,8 +20,6 @@ import symmetricDifference from 'set.prototype.symmetricdifference';
 import setUnion from 'set.prototype.union';
 import { z } from 'zod/v4';
 
-import type { AssertionFailure } from '../assertion-types.js';
-
 import { isWeakKey } from '../../guards.js';
 import {
   KeypathSchema,
@@ -58,7 +56,7 @@ export const mapContainsAssertion = createAssertion(
     ['to contain', 'to include'],
     z.unknown(),
   ],
-  (subject, key): AssertionFailure | boolean => {
+  (subject, key) => {
     // WeakMap.has only works with object or symbol keys
     let hasKey: boolean;
     if (subject instanceof WeakMap) {
@@ -102,7 +100,7 @@ export const mapContainsAssertion = createAssertion(
  */
 export const mapSizeAssertion = createAssertion(
   [z.map(z.unknown(), z.unknown()), 'to have size', NonNegativeIntegerSchema],
-  (subject, expectedSize): AssertionFailure | boolean => {
+  (subject, expectedSize) => {
     if (subject.size === expectedSize) {
       return true;
     }
@@ -155,7 +153,7 @@ export const setContainsAssertion = createAssertion(
     ['to contain', 'to include'],
     z.any(),
   ],
-  (subject, value): AssertionFailure | boolean => {
+  (subject, value) => {
     // WeakSet.has only works with object or symbol values
     if (subject instanceof WeakSet && !isWeakKey(value)) {
       return {
@@ -245,7 +243,7 @@ export const emptySetAssertion = createAssertion(
  */
 export const arrayContainsAssertion = createAssertion(
   [z.array(z.any()), ['to contain', 'to include'], z.any()],
-  (subject, value): AssertionFailure | boolean => {
+  (subject, value) => {
     if (subject.includes(value)) {
       return true;
     }
@@ -271,7 +269,7 @@ export const arrayContainsAssertion = createAssertion(
  */
 export const arraySizeAssertion = createAssertion(
   [z.array(z.any()), 'to have size', NonNegativeIntegerSchema],
-  (subject, expectedSize): AssertionFailure | boolean => {
+  (subject, expectedSize) => {
     if (subject.length === expectedSize) {
       return true;
     }
@@ -720,7 +718,7 @@ export const setSymmetricDifferenceEqualityAssertion = createAssertion(
  */
 export const mapKeyAssertion = createAssertion(
   [z.map(z.unknown(), z.unknown()), 'to have key', z.unknown()],
-  (map, key): AssertionFailure | boolean => {
+  (map, key) => {
     if (map.has(key)) {
       return true;
     }
@@ -747,7 +745,7 @@ export const mapKeyAssertion = createAssertion(
  */
 export const mapValueAssertion = createAssertion(
   [z.map(z.unknown(), z.unknown()), 'to have value', z.unknown()],
-  (map, value): AssertionFailure | boolean => {
+  (map, value) => {
     for (const mapValue of map.values()) {
       if (mapValue === value) {
         return true;
@@ -780,7 +778,7 @@ export const mapEntryAssertion = createAssertion(
     'to have entry',
     z.tuple([z.unknown(), z.unknown()]),
   ],
-  (map, [key, value]): AssertionFailure | boolean => {
+  (map, [key, value]) => {
     // WeakMap operations only work with object or symbol keys
     if (map instanceof WeakMap && !isWeakKey(key)) {
       return {
@@ -834,7 +832,7 @@ export const mapEqualityAssertion = createAssertion(
     'to equal',
     z.map(z.unknown(), z.unknown()),
   ],
-  (mapA, mapB): AssertionFailure | boolean => {
+  (mapA, mapB) => {
     if (mapA.size !== mapB.size) {
       return {
         actual: mapA.size,
@@ -880,7 +878,7 @@ export const collectionSizeGreaterThanAssertion = createAssertion(
     'to have size greater than',
     NonNegativeIntegerSchema,
   ],
-  (collection, minSize): AssertionFailure | boolean => {
+  (collection, minSize) => {
     if (collection.size > minSize) {
       return true;
     }
@@ -910,7 +908,7 @@ export const collectionSizeLessThanAssertion = createAssertion(
     'to have size less than',
     NonNegativeIntegerSchema,
   ],
-  (collection, maxSize): AssertionFailure | boolean => {
+  (collection, maxSize) => {
     if (collection.size < maxSize) {
       return true;
     }
@@ -940,7 +938,7 @@ export const collectionSizeBetweenAssertion = createAssertion(
     'to have size between',
     z.tuple([z.number(), z.number()]),
   ],
-  (collection, [min, max]): AssertionFailure | boolean => {
+  (collection, [min, max]) => {
     const size = collection.size;
     if (size >= min && size <= max) {
       return true;

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -84,3 +84,10 @@ export const KEYPATH_REGEX =
  * @internal
  */
 export const kBupkisError: unique symbol = Symbol('bupkis-error');
+
+/**
+ * Assertion ID of a `FailAssertionError`.
+ *
+ * @internal
+ */
+export const FAIL = 'FAIL' as const;

--- a/test/assertion-error/assert-error.test.ts.snapshot
+++ b/test/assertion-error/assert-error.test.ts.snapshot
@@ -16,7 +16,8 @@ exports[`Comparison with Node.js' assert module > deepStrictEqual / \"to deep eq
       "c": 3
     }
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "object-to-deep-equal-to-deeply-equal-any-3s3p"
 }
 `;
 

--- a/test/assertion-error/async-parametric-error.test.ts.snapshot
+++ b/test/assertion-error/async-parametric-error.test.ts.snapshot
@@ -6,7 +6,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{function} 'to fulfill w
   "code": "ERR_ASSERTION",
   "actual": "wrong",
   "expected": 42,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-fulfill-with-value-satisfying-to-resolve-with-value-satisfying-any-3s3p"
 }
 `;
 
@@ -18,7 +19,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{function} 'to reject wi
   "code": "ERR_ASSERTION",
   "actual": "Error",
   "expected": "TypeError",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-reject-with-a-to-reject-with-an-constructible-3s3p"
 }
 `;
 
@@ -32,7 +34,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{function} 'to reject wi
   "expected": {
     "message": "expected message"
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-reject-with-error-satisfying-any-3s3p"
 }
 `;
 
@@ -44,7 +47,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{function} 'to reject'\"
   "code": "ERR_ASSERTION",
   "actual": "function fulfilled",
   "expected": "function rejected",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-reject-2s2p"
 }
 `;
 
@@ -56,7 +60,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{function} 'to resolve' 
   "code": "ERR_ASSERTION",
   "actual": "function rejected",
   "expected": "function to fulfill",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-resolve-to-fulfill-2s2p"
 }
 `;
 
@@ -68,7 +73,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{promiselike} 'to fulfil
   "code": "ERR_ASSERTION",
   "actual": "wrong",
   "expected": 42,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "promiselike-to-fulfill-with-value-satisfying-to-resolve-with-value-satisfying-any-3s3p"
 }
 `;
 
@@ -80,7 +86,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{promiselike} 'to reject
   "code": "ERR_ASSERTION",
   "actual": "Error",
   "expected": "TypeError",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "promiselike-to-reject-with-a-to-reject-with-an-constructible-3s3p"
 }
 `;
 
@@ -94,7 +101,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{promiselike} 'to reject
   "expected": {
     "message": "expected message"
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "promiselike-to-reject-with-error-satisfying-any-3s3p"
 }
 `;
 
@@ -106,7 +114,8 @@ exports[`Async Parametric Assertion Error Snapshots > \"{promiselike} 'to reject
   "code": "ERR_ASSERTION",
   "actual": "Promise fulfilled",
   "expected": "Promise rejected",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "promiselike-to-reject-2s2p"
 }
 `;
 
@@ -118,6 +127,7 @@ exports[`Async Parametric Assertion Error Snapshots > \"{promiselike} 'to resolv
   "code": "ERR_ASSERTION",
   "actual": "promise rejected",
   "expected": "promise to not reject",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "promiselike-to-resolve-to-fulfill-2s2p"
 }
 `;

--- a/test/assertion-error/sync-basic-error.test.ts.snapshot
+++ b/test/assertion-error/sync-basic-error.test.ts.snapshot
@@ -84,7 +84,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be NaN'\" [unkno
   "code": "ERR_ASSERTION",
   "actual": 42,
   "expected": "<nan>",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-nan-2s1p"
 }
 `;
 
@@ -95,7 +96,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a RegExp' / '
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "hello",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-regexp-to-be-a-regex-to-be-a-regexp-2s1p"
 }
 `;
 
@@ -107,7 +109,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a Set'\" [unk
   "code": "ERR_ASSERTION",
   "actual": "hello",
   "expected": "<set>",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-set-2s1p"
 }
 `;
 
@@ -118,7 +121,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a WeakMap'\" 
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "hello",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-weakmap-2s1p"
 }
 `;
 
@@ -129,7 +133,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a WeakSet'\" 
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "hello",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-weakset-2s1p"
 }
 `;
 
@@ -141,7 +146,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a bigint' / '
   "code": "ERR_ASSERTION",
   "actual": 42,
   "expected": "<bigint>",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-bigint-to-be-a-bigint-2s1p"
 }
 `;
 
@@ -153,7 +159,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a boolean' / 
   "code": "ERR_ASSERTION",
   "actual": "hello",
   "expected": true,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-boolean-to-be-boolean-to-be-a-bool-2s1p"
 }
 `;
 
@@ -164,7 +171,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a class' / 't
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "hello",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-class-to-be-a-constructor-to-be-constructible-2s1p"
 }
 `;
 
@@ -176,7 +184,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a date' / 'to
   "code": "ERR_ASSERTION",
   "actual": "hello",
   "expected": "<date>",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-date-to-be-a-date-2s1p"
 }
 `;
 
@@ -187,7 +196,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a function'\"
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "hello",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-function-2s1p"
 }
 `;
 
@@ -199,7 +209,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a negative in
   "code": "ERR_ASSERTION",
   "actual": 5,
   "expected": 0,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-negative-integer-to-be-a-negative-int-2s1p"
 }
 `;
 
@@ -211,7 +222,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a number' / '
   "code": "ERR_ASSERTION",
   "actual": "hello",
   "expected": 0,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-number-to-be-finite-2s1p"
 }
 `;
 
@@ -223,7 +235,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a positive in
   "code": "ERR_ASSERTION",
   "actual": -5,
   "expected": 0,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-positive-integer-to-be-a-positive-int-2s1p"
 }
 `;
 
@@ -235,7 +248,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a primitive'\
   "code": "ERR_ASSERTION",
   "actual": {},
   "expected": {},
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-primitive-2s1p"
 }
 `;
 
@@ -247,7 +261,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a record' / '
   "code": "ERR_ASSERTION",
   "actual": [],
   "expected": "<record>",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-record-to-be-a-plain-object-2s1p"
 }
 `;
 
@@ -259,7 +274,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a string'\" [
   "code": "ERR_ASSERTION",
   "actual": 42,
   "expected": "42",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-string-2s1p"
 }
 `;
 
@@ -271,7 +287,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be a symbol' / '
   "code": "ERR_ASSERTION",
   "actual": "hello",
   "expected": "<symbol>",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-symbol-to-be-a-symbol-2s1p"
 }
 `;
 
@@ -295,7 +312,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be an array' / '
   "code": "ERR_ASSERTION",
   "actual": 42,
   "expected": [],
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-an-array-to-be-array-2s1p"
 }
 `;
 
@@ -305,7 +323,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be an async func
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-an-async-function-2s1p"
 }
 `;
 
@@ -317,7 +336,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be an integer' /
   "code": "ERR_ASSERTION",
   "actual": 3.14,
   "expected": "<int>",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-an-integer-to-be-a-safe-integer-to-be-an-int-to-be-a-safe-int-2s1p"
 }
 `;
 
@@ -328,7 +348,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be an object'\" 
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "hello",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-an-object-2s1p"
 }
 `;
 
@@ -338,7 +359,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be defined'\" [u
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-defined-2s1p"
 }
 `;
 
@@ -350,7 +372,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be false'\" [unk
   "code": "ERR_ASSERTION",
   "actual": true,
   "expected": false,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-false-2s1p"
 }
 `;
 
@@ -361,7 +384,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be falsy'\" [unk
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": 1,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-falsy-2s1p"
 }
 `;
 
@@ -372,7 +396,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be infinite'\" [
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": 42,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-infinite-2s1p"
 }
 `;
 
@@ -384,7 +409,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be negative' / '
   "code": "ERR_ASSERTION",
   "actual": 5,
   "expected": 0,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-negative-to-be-a-negative-number-2s1p"
 }
 `;
 
@@ -394,7 +420,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be null'\" [unkn
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-null-2s1p"
 }
 `;
 
@@ -406,7 +433,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be positive' / '
   "code": "ERR_ASSERTION",
   "actual": -5,
   "expected": 0,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-positive-to-be-a-positive-number-2s1p"
 }
 `;
 
@@ -418,7 +446,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be true'\" [unkn
   "code": "ERR_ASSERTION",
   "actual": false,
   "expected": true,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-true-2s1p"
 }
 `;
 
@@ -429,7 +458,8 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be truthy' / 'to
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": 0,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-truthy-to-exist-to-be-ok-2s1p"
 }
 `;
 
@@ -440,6 +470,7 @@ exports[`Sync Basic Assertion Error Snapshots > \"{unknown} 'to be undefined'\" 
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": null,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-undefined-2s1p"
 }
 `;

--- a/test/assertion-error/sync-collection-error.test.ts.snapshot
+++ b/test/assertion-error/sync-collection-error.test.ts.snapshot
@@ -6,7 +6,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown> | 
   "code": "ERR_ASSERTION",
   "actual": 4,
   "expected": "size between 1 and 3 (inclusive)",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-set_unknown-to-have-size-between-number-number-3s3p"
 }
 `;
 
@@ -18,7 +19,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown> | 
   "code": "ERR_ASSERTION",
   "actual": 1,
   "expected": "size greater than 2",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-set_unknown-to-have-size-greater-than-nonnegative_integer-3s3p"
 }
 `;
 
@@ -30,7 +32,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown> | 
   "code": "ERR_ASSERTION",
   "actual": 3,
   "expected": "size less than 2",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-set_unknown-to-have-size-less-than-nonnegative_integer-3s3p"
 }
 `;
 
@@ -42,7 +45,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown> | 
   "code": "ERR_ASSERTION",
   "actual": "missing",
   "expected": "key to exist in Map",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-weakmap-to-contain-to-include-unknown-3s3p"
 }
 `;
 
@@ -60,7 +64,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown> | 
     "key",
     "wrong"
   ],
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-weakmap-to-have-entry-unknown-unknown-3s3p"
 }
 `;
 
@@ -70,7 +75,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown>} '
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-to-be-empty-2s2p"
 }
 `;
 
@@ -88,7 +94,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown>} '
     "b",
     2
   ],
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-to-equal-map_unknown-unknown-3s3p"
 }
 `;
 
@@ -102,7 +109,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown>} '
     "key"
   ],
   "expected": "missing",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-to-have-key-unknown-3s3p"
 }
 `;
 
@@ -114,7 +122,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown>} '
   "code": "ERR_ASSERTION",
   "actual": 2,
   "expected": 3,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-to-have-size-nonnegative_integer-3s3p"
 }
 `;
 
@@ -128,7 +137,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Map<unknown, unknown>} '
     "value"
   ],
   "expected": "missing",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "map_unknown-unknown-to-have-value-unknown-3s3p"
 }
 `;
 
@@ -140,7 +150,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown> | WeakSet} 
   "code": "ERR_ASSERTION",
   "actual": "c",
   "expected": "value to exist in Set",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-weakset-to-contain-to-include-any-3s3p"
 }
 `;
 
@@ -150,7 +161,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to be a s
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-be-a-subset-of-set_unknown-3s3p"
 }
 `;
 
@@ -160,7 +172,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to be a s
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-be-a-superset-of-set_unknown-3s3p"
 }
 `;
 
@@ -170,7 +183,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to be dis
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-be-disjoint-from-set_unknown-3s3p"
 }
 `;
 
@@ -182,7 +196,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to be emp
   "code": "ERR_ASSERTION",
   "actual": 1,
   "expected": 0,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-be-empty-2s2p"
 }
 `;
 
@@ -192,7 +207,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to equal'
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-equal-set_unknown-3s3p"
 }
 `;
 
@@ -202,7 +218,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to have d
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-have-difference-set_unknown-equal-to-set_unknown-5s5p"
 }
 `;
 
@@ -212,7 +229,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to have i
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-have-intersection-set_unknown-equal-to-set_unknown-5s5p"
 }
 `;
 
@@ -224,7 +242,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to have s
   "code": "ERR_ASSERTION",
   "actual": 2,
   "expected": 3,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-have-size-nonnegative_integer-3s3p"
 }
 `;
 
@@ -234,7 +253,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to have s
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-have-symmetric-difference-set_unknown-equal-to-set_unknown-5s5p"
 }
 `;
 
@@ -244,7 +264,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to have u
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-have-union-set_unknown-equal-to-set_unknown-5s5p"
 }
 `;
 
@@ -254,7 +275,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{Set<unknown>} 'to inters
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "set_unknown-to-intersect-with-set_unknown-3s3p"
 }
 `;
 
@@ -270,7 +292,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{any[]} 'to contain' / 't
     3
   ],
   "expected": "array containing 4",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "any-to-contain-to-include-any-3s3p"
 }
 `;
 
@@ -282,7 +305,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{any[]} 'to have size' {n
   "code": "ERR_ASSERTION",
   "actual": 3,
   "expected": 5,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "any-to-have-size-nonnegative_integer-3s3p"
 }
 `;
 
@@ -298,7 +322,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{non-collection-object} '
   "expected": {
     "foo": "bar"
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "non_collection_object-to-have-exact-key-to-have-exact-property-to-have-exact-prop-property_key-3s3p"
 }
 `;
 
@@ -309,7 +334,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{non-collection-object} '
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "no such keypath",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "non_collection_object-to-have-key-to-have-property-to-have-prop-keypath-3s3p"
 }
 `;
 
@@ -321,7 +347,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{non-collection-object} '
   "code": "ERR_ASSERTION",
   "actual": "missing keys: b",
   "expected": "to have keys: a, b",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "non_collection_object-to-have-keys-to-have-properties-to-have-props-string-3s3p"
 }
 `;
 
@@ -333,7 +360,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{object} 'to have size' {
   "code": "ERR_ASSERTION",
   "actual": 1,
   "expected": 3,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "object-to-have-size-nonnegative_integer-3s3p"
 }
 `;
 
@@ -345,7 +373,8 @@ exports[`Sync Collection Assertion Error Snapshots > \"{unknown[]} 'to be non-em
   "code": "ERR_ASSERTION",
   "actual": "length: 0",
   "expected": "length greater than 0",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-non_empty-2s2p"
 }
 `;
 
@@ -367,6 +396,7 @@ exports[`Sync Collection Assertion Error Snapshots > \"{unknown[]} 'to have leng
     null,
     null
   ],
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-have-length-nonnegative_integer-3s3p"
 }
 `;

--- a/test/assertion-error/sync-esoteric-error.test.ts.snapshot
+++ b/test/assertion-error/sync-esoteric-error.test.ts.snapshot
@@ -6,7 +6,8 @@ exports[`Sync Esoteric Assertion Error Snapshots > \"{property-key} 'to be an en
   "code": "ERR_ASSERTION",
   "actual": false,
   "expected": true,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "property_key-to-be-an-enumerable-property-of-unknown-3s3p"
 }
 `;
 
@@ -22,7 +23,8 @@ exports[`Sync Esoteric Assertion Error Snapshots > \"{unknown!} 'to have enumera
   "expected": {
     "visible": "value"
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-have-enumerable-property-property_key-3s3p"
 }
 `;
 
@@ -34,7 +36,8 @@ exports[`Sync Esoteric Assertion Error Snapshots > \"{unknown} 'to be extensible
   "code": "ERR_ASSERTION",
   "actual": {},
   "expected": {},
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-extensible-2s1p"
 }
 `;
 
@@ -46,7 +49,8 @@ exports[`Sync Esoteric Assertion Error Snapshots > \"{unknown} 'to be frozen'\" 
   "code": "ERR_ASSERTION",
   "actual": false,
   "expected": true,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-frozen-2s1p"
 }
 `;
 
@@ -62,7 +66,8 @@ exports[`Sync Esoteric Assertion Error Snapshots > \"{unknown} 'to be sealed'\" 
   "expected": {
     "prop": "value"
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-sealed-2s1p"
 }
 `;
 
@@ -74,6 +79,7 @@ exports[`Sync Esoteric Assertion Error Snapshots > \"{unknown} 'to have a null p
   "code": "ERR_ASSERTION",
   "actual": {},
   "expected": {},
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-have-a-null-prototype-to-be-a-dictionary-2s1p"
 }
 `;

--- a/test/assertion-error/sync-parametric-error.test.ts.snapshot
+++ b/test/assertion-error/sync-parametric-error.test.ts.snapshot
@@ -6,7 +6,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{Error} 'to have message 
   "code": "ERR_ASSERTION",
   "actual": "wrong message",
   "expected": "message matching /expected/",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "error-to-have-message-matching-regexp-3s3p"
 }
 `;
 
@@ -18,7 +19,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{Error} 'to have message'
   "code": "ERR_ASSERTION",
   "actual": "wrong message",
   "expected": "expected message",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "error-to-have-message-string-3s3p"
 }
 `;
 
@@ -30,7 +32,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{any} 'to be a' / 'to be 
   "code": "ERR_ASSERTION",
   "actual": "hello",
   "expected": 0,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "any-to-be-a-to-be-an-to-have-type-string-number-boolean-undefined-null-bigint-bigint-symbol-symbol-object-object-function-function-array-array-date-date-map-map-set-set-weakmap-weakmap-weakset-weakset-regexp-regexp-promise-promise-error-error-weakref-weakref-3s3p"
 }
 `;
 
@@ -50,7 +53,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{arraylike} 'to deep equa
     2,
     4
   ],
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "arraylike-to-deep-equal-to-deeply-equal-any-3s3p"
 }
 `;
 
@@ -70,7 +74,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{arraylike} 'to satisfy' 
     2,
     4
   ],
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "arraylike-to-satisfy-to-be-like-any-3s3p"
 }
 `;
 
@@ -82,7 +87,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{function} 'to have arity
   "code": "ERR_ASSERTION",
   "actual": 2,
   "expected": 3,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-have-arity-nonnegative_integer-3s3p"
 }
 `;
 
@@ -96,7 +102,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{function} 'to throw a' /
   "expected": {
     "message": "expected message"
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-throw-a-to-throw-an-constructible-satisfying-any-5s5p"
 }
 `;
 
@@ -108,7 +115,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{function} 'to throw a' /
   "code": "ERR_ASSERTION",
   "actual": "Error",
   "expected": "TypeError",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-throw-a-to-throw-an-constructible-3s3p"
 }
 `;
 
@@ -132,7 +140,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{function} 'to throw'\" [
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "no error",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "function-to-throw-2s2p"
 }
 `;
 
@@ -144,7 +153,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{number} 'to be close to'
   "code": "ERR_ASSERTION",
   "actual": 10,
   "expected": 5,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "number-to-be-close-to-number-number-4s4p"
 }
 `;
 
@@ -156,7 +166,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{number} 'to be greater t
   "code": "ERR_ASSERTION",
   "actual": 5,
   "expected": 10,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "number-to-be-greater-than-or-equal-to-to-be-at-least-to-be-gte-number-3s3p"
 }
 `;
 
@@ -168,7 +179,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{number} 'to be greater t
   "code": "ERR_ASSERTION",
   "actual": 5,
   "expected": 10,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "number-to-be-greater-than-number-3s3p"
 }
 `;
 
@@ -180,7 +192,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{number} 'to be less than
   "code": "ERR_ASSERTION",
   "actual": 10,
   "expected": 5,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "number-to-be-less-than-or-equal-to-to-be-at-most-to-be-lte-number-3s3p"
 }
 `;
 
@@ -192,7 +205,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{number} 'to be less than
   "code": "ERR_ASSERTION",
   "actual": 10,
   "expected": 5,
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "number-to-be-less-than-to-be-lt-number-3s3p"
 }
 `;
 
@@ -226,7 +240,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{object!} 'to satisfy' / 
     "a": 1,
     "b": 3
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "object-to-satisfy-to-be-like-satisfies-any-3s3p"
 }
 `;
 
@@ -244,7 +259,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{object} 'to deep equal' 
     "a": 1,
     "b": 3
   },
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "object-to-deep-equal-to-deeply-equal-any-3s3p"
 }
 `;
 
@@ -256,7 +272,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{string} 'includes' / 'co
   "code": "ERR_ASSERTION",
   "actual": "hello world",
   "expected": "string including \\"universe\\"",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "string-includes-contains-to-include-to-contain-string-3s3p"
 }
 `;
 
@@ -268,7 +285,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{string} 'to be greater t
   "code": "ERR_ASSERTION",
   "actual": "apple",
   "expected": "string greater than or equal to \\"zebra\\"",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "string-to-be-greater-than-or-equal-to-string-3s3p"
 }
 `;
 
@@ -280,7 +298,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{string} 'to be greater t
   "code": "ERR_ASSERTION",
   "actual": "apple",
   "expected": "string greater than \\"zebra\\"",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "string-to-be-greater-than-string-3s3p"
 }
 `;
 
@@ -292,7 +311,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{string} 'to be less than
   "code": "ERR_ASSERTION",
   "actual": "zebra",
   "expected": "string less than or equal to \\"apple\\"",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "string-to-be-less-than-or-equal-to-string-3s3p"
 }
 `;
 
@@ -304,7 +324,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{string} 'to be less than
   "code": "ERR_ASSERTION",
   "actual": "zebra",
   "expected": "string less than \\"apple\\"",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "string-to-be-less-than-string-3s3p"
 }
 `;
 
@@ -316,7 +337,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{string} 'to begin with' 
   "code": "ERR_ASSERTION",
   "actual": "hello world",
   "expected": "string beginning with \\"goodbye\\"",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "string-to-begin-with-to-start-with-string-3s3p"
 }
 `;
 
@@ -328,7 +350,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{string} 'to end with' {s
   "code": "ERR_ASSERTION",
   "actual": "hello world",
   "expected": "string ending with \\"universe\\"",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "string-to-end-with-string-3s3p"
 }
 `;
 
@@ -338,7 +361,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{string} 'to match' {rege
   "generatedMessage": false,
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "string-to-match-regexp-3s3p"
 }
 `;
 
@@ -349,7 +373,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{unknown} 'to be an insta
   "name": "AssertionError",
   "code": "ERR_ASSERTION",
   "actual": "hello",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-an-instance-of-to-be-a-to-be-an-constructible-3s2p"
 }
 `;
 
@@ -361,7 +386,8 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{unknown} 'to be one of' 
   "code": "ERR_ASSERTION",
   "actual": 5,
   "expected": "one of [1, 2, 3]",
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-one-of-any-3s2p"
 }
 `;
 
@@ -373,6 +399,7 @@ exports[`Sync Parametric Assertion Error Snapshots > \"{unknown} 'to be' / 'to e
   "code": "ERR_ASSERTION",
   "actual": {},
   "expected": {},
-  "diff": "simple"
+  "diff": "simple",
+  "assertionId": "unknown-to-be-to-equal-equals-is-is-equal-to-to-strictly-equal-is-strictly-equal-to-unknown-3s2p"
 }
 `;

--- a/test/core/assertion-error.test.ts
+++ b/test/core/assertion-error.test.ts
@@ -8,7 +8,9 @@ import {
 } from '../../src/constant.js';
 import {
   AssertionError,
+  type AssertionErrorOptions,
   FailAssertionError,
+  type FailAssertionErrorOptions,
   NegatedAssertionError,
 } from '../../src/error.js';
 import { expect } from '../../src/index.js';
@@ -17,46 +19,53 @@ describe('core API', () => {
   describe('AssertionError', () => {
     describe('constructor', () => {
       it('should extend Node.js AssertionError', () => {
-        const error = new AssertionError({ message: 'test error' });
+        const error = new AssertionError({ id: 'foo', message: 'test error' });
         expect(error, 'to be an instance of', NodeAssertionError);
         expect(error, 'to be an instance of', AssertionError);
       });
 
       it('should have correct name', () => {
-        const error = new AssertionError({ message: 'test error' });
+        const error = new AssertionError({ id: 'foo', message: 'test error' });
         expect(error.name, 'to equal', 'AssertionError');
       });
 
       it('should have the bupkis marker symbol', () => {
-        const error = new AssertionError({ message: 'test error' });
+        const error = new AssertionError({ id: 'foo', message: 'test error' });
         expect(error[kBupkisAssertionError], 'to be true');
       });
 
       it('should preserve message and other properties', () => {
-        const options = {
+        const options: AssertionErrorOptions = {
           actual: 'actual value',
           expected: 'expected value',
+          id: 'foo',
           message: 'Custom error message',
-          operator: 'strictEqual',
         };
         const error = new AssertionError(options);
         // Note: Node.js AssertionError formats the message when actual/expected are provided
-        expect(error.message, 'to contain', 'Custom error message');
-        expect(error.actual, 'to equal', 'actual value');
-        expect(error.expected, 'to equal', 'expected value');
-        expect(error.operator, 'to equal', 'strictEqual');
+        expect(error, 'to satisfy', {
+          actual: 'actual value',
+          assertionId: 'foo',
+          expected: 'expected value',
+          message: /Custom error message/,
+        });
       });
     });
 
     describe('isAssertionError', () => {
       it('should return true for AssertionError instances', () => {
-        const error = new AssertionError({ message: 'test' });
+        const error = new AssertionError({ id: 'foo', message: 'test' });
         expect(AssertionError.isAssertionError(error), 'to be true');
       });
 
       it('should return true for subclass instances', () => {
-        const failError = new FailAssertionError({ message: 'test' });
-        const negatedError = new NegatedAssertionError({ message: 'test' });
+        const failError = new FailAssertionError({
+          message: 'test',
+        });
+        const negatedError = new NegatedAssertionError({
+          id: 'foo',
+          message: 'test',
+        });
         expect(AssertionError.isAssertionError(failError), 'to be true');
         expect(AssertionError.isAssertionError(negatedError), 'to be true');
       });
@@ -88,25 +97,31 @@ describe('core API', () => {
 describe('FailAssertionError', () => {
   describe('constructor', () => {
     it('should extend AssertionError', () => {
-      const error = new FailAssertionError({ message: 'test error' });
+      const error = new FailAssertionError({
+        message: 'test error',
+      });
       expect(error, 'to be an instance of', AssertionError);
       expect(error, 'to be an instance of', FailAssertionError);
       expect(error, 'to be an instance of', NodeAssertionError);
     });
 
     it('should have correct name', () => {
-      const error = new FailAssertionError({ message: 'test error' });
+      const error = new FailAssertionError({
+        message: 'test error',
+      });
       expect(error.name, 'to equal', 'FailAssertionError');
     });
 
     it('should have both bupkis marker symbols', () => {
-      const error = new FailAssertionError({ message: 'test error' });
+      const error = new FailAssertionError({
+        message: 'test error',
+      });
       expect(error[kBupkisAssertionError], 'to be true');
       expect(error[kBupkisFailAssertionError], 'to be true');
     });
 
     it('should preserve message and other properties', () => {
-      const options = {
+      const options: FailAssertionErrorOptions = {
         actual: 'actual value',
         expected: 'expected value',
         message: 'Fail error message',
@@ -125,12 +140,12 @@ describe('FailAssertionError', () => {
     });
 
     it('should return false for regular AssertionError', () => {
-      const error = new AssertionError({ message: 'test' });
+      const error = new AssertionError({ id: 'foo', message: 'test' });
       expect(FailAssertionError.isFailAssertionError(error), 'to be false');
     });
 
     it('should return false for NegatedAssertionError', () => {
-      const error = new NegatedAssertionError({ message: 'test' });
+      const error = new NegatedAssertionError({ id: 'foo', message: 'test' });
       expect(FailAssertionError.isFailAssertionError(error), 'to be false');
     });
 
@@ -154,27 +169,37 @@ describe('FailAssertionError', () => {
 describe('NegatedAssertionError', () => {
   describe('constructor', () => {
     it('should extend AssertionError', () => {
-      const error = new NegatedAssertionError({ message: 'test error' });
+      const error = new NegatedAssertionError({
+        id: 'foo',
+        message: 'test error',
+      });
       expect(error, 'to be an instance of', AssertionError);
       expect(error, 'to be an instance of', NegatedAssertionError);
       expect(error, 'to be an instance of', NodeAssertionError);
     });
 
     it('should have correct name', () => {
-      const error = new NegatedAssertionError({ message: 'test error' });
+      const error = new NegatedAssertionError({
+        id: 'foo',
+        message: 'test error',
+      });
       expect(error.name, 'to equal', 'NegatedAssertionError');
     });
 
     it('should have both bupkis marker symbols', () => {
-      const error = new NegatedAssertionError({ message: 'test error' });
+      const error = new NegatedAssertionError({
+        id: 'foo',
+        message: 'test error',
+      });
       expect(error[kBupkisAssertionError], 'to be true');
       expect(error[kBupkisNegatedAssertionError], 'to be true');
     });
 
     it('should preserve message and other properties', () => {
-      const options = {
+      const options: AssertionErrorOptions = {
         actual: 'actual value',
         expected: 'expected value',
+        id: 'foo',
         message: 'Negated error message',
       };
       const error = new NegatedAssertionError(options);
@@ -186,7 +211,7 @@ describe('NegatedAssertionError', () => {
 
   describe('isNegatedAssertionError', () => {
     it('should return true for NegatedAssertionError instances', () => {
-      const error = new NegatedAssertionError({ message: 'test' });
+      const error = new NegatedAssertionError({ id: 'foo', message: 'test' });
       expect(
         NegatedAssertionError.isNegatedAssertionError(error),
         'to be true',
@@ -194,7 +219,7 @@ describe('NegatedAssertionError', () => {
     });
 
     it('should return false for regular AssertionError', () => {
-      const error = new AssertionError({ message: 'test' });
+      const error = new AssertionError({ id: 'foo', message: 'test' });
       expect(
         NegatedAssertionError.isNegatedAssertionError(error),
         'to be false',
@@ -241,9 +266,12 @@ describe('NegatedAssertionError', () => {
   });
   describe('Error hierarchy and inheritance', () => {
     it('should maintain correct inheritance chain', () => {
-      const assertionError = new AssertionError({ message: 'test' });
+      const assertionError = new AssertionError({ id: 'foo', message: 'test' });
       const failError = new FailAssertionError({ message: 'test' });
-      const negatedError = new NegatedAssertionError({ message: 'test' });
+      const negatedError = new NegatedAssertionError({
+        id: 'foo',
+        message: 'test',
+      });
 
       // All should be instances of base classes
       expect(assertionError, 'to be an instance of', NodeAssertionError);
@@ -283,7 +311,7 @@ describe('NegatedAssertionError', () => {
     });
 
     it('should handle stack traces properly', () => {
-      const error = new AssertionError({ message: 'test error' });
+      const error = new AssertionError({ id: 'foo', message: 'test error' });
       expect(error.stack, 'to be a string');
       expect(error.stack, 'to contain', 'test error');
     });
@@ -314,12 +342,14 @@ describe('NegatedAssertionError', () => {
       const createErrorWithStackStart = () => {
         // Create error without stackStartFn - should include this function in stack
         const errorWithoutStackStart = new AssertionError({
+          id: 'foo',
           message: 'without stackStartFn',
         });
 
         // Create error with stackStartFn - should exclude this function from stack
         // This is useful for hiding internal implementation details from users
         const errorWithStackStart = new AssertionError({
+          id: 'foo',
           message: 'with stackStartFn',
           stackStartFn: createErrorWithStackStart,
         });

--- a/test/core/create-assertion.test.ts
+++ b/test/core/create-assertion.test.ts
@@ -151,14 +151,22 @@ describe('core API', () => {
     });
 
     describe('with function implementation', () => {
-      it('should create a BupkisAssertionFunctionAsync instance', () => {
-        const assertion = expect.createAsyncAssertion(
-          ['to be truthy'],
-          async (value) => Boolean(value),
-        );
+      const assertion = expect.createAsyncAssertion(
+        ['to be truthy'],
+        async (value) => Boolean(value),
+      );
 
-        expect(assertion, 'to be a', BupkisAssertionFunctionAsync);
-        expect(assertion.parts, 'to satisfy', ['to be truthy']);
+      describe('which returns a boolean', () => {
+        it('should create a BupkisAssertionFunctionAsync instance', () => {
+          expect(
+            assertion,
+            'to be a',
+            BupkisAssertionFunctionAsync,
+            'and',
+            'to satisfy',
+            { parts: ['to be truthy'] },
+          );
+        });
       });
     });
 

--- a/test/custom-assertions.ts
+++ b/test/custom-assertions.ts
@@ -1,7 +1,6 @@
 import setDifference from 'set.prototype.difference';
 
 import { BupkisAssertion } from '../src/assertion/assertion.js';
-import { AssertionError } from '../src/error.js';
 import { expect as builtinExpect, z } from '../src/index.js';
 import { type AnyAssertion } from '../src/types.js';
 import { keyBy } from '../src/util.js';
@@ -30,11 +29,12 @@ const exhaustiveAssertionTestAssertion = builtinExpect.createAssertion(
       builtinExpect(diff, 'to be empty');
     } catch {
       /* c8 ignore next */
-      throw new AssertionError({
+      return {
         actual: testedIds,
         expected: allCollectionIds,
+        id: 'test',
         message: `Some assertions in collection "${collectionName}" are missing property test configurations`,
-      });
+      };
     }
   },
 );

--- a/test/error/error.test.ts
+++ b/test/error/error.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 
 import {
   AssertionError,
+  type AssertionErrorOptions,
   AssertionImplementationError,
   BupkisError,
   FailAssertionError,
@@ -18,7 +19,7 @@ import { expect } from '../custom-assertions.js';
 describe('Error classes', () => {
   describe('AssertionError', () => {
     it('should create instance with default options', () => {
-      const error = new AssertionError({});
+      const error = new AssertionError({ id: 'test' });
 
       expect(
         error,
@@ -33,18 +34,24 @@ describe('Error classes', () => {
     });
 
     it('should create instance with custom options', () => {
-      const options = {
+      const options: AssertionErrorOptions = {
         actual: 'foo',
         expected: 'bar',
+        id: 'test',
         message: 'Test assertion failed',
       };
       const error = new AssertionError(options);
 
-      expect(error, 'to satisfy', options);
+      expect(error, 'to satisfy', {
+        actual: 'foo',
+        assertionId: 'test',
+        expected: 'bar',
+        message: 'Test assertion failed',
+      });
     });
 
     it('should have proper type guard', () => {
-      const error = new AssertionError({});
+      const error = new AssertionError({ id: 'test' });
       const nodeError = new NodeAssertionError({ message: 'test' });
 
       expect(AssertionError.isAssertionError(error), 'to be true');
@@ -57,6 +64,7 @@ describe('Error classes', () => {
       const error = new AssertionError({
         actual: 42,
         expected: 'string',
+        id: 'test',
         message: 'Test message',
       });
 
@@ -148,8 +156,8 @@ describe('Error classes', () => {
     });
 
     it('should have proper type guard', () => {
-      const failError = new FailAssertionError({});
-      const assertionError = new AssertionError({});
+      const failError = new FailAssertionError();
+      const assertionError = new AssertionError({ id: 'test' });
 
       expect(FailAssertionError.isFailAssertionError(failError), 'to be true');
       expect(
@@ -231,6 +239,7 @@ describe('Error classes', () => {
       const error = new NegatedAssertionError({
         actual: false,
         expected: true,
+        id: 'test',
         message: 'Negated assertion failed',
       });
 
@@ -251,8 +260,8 @@ describe('Error classes', () => {
     });
 
     it('should have proper type guard', () => {
-      const negatedError = new NegatedAssertionError({});
-      const assertionError = new AssertionError({});
+      const negatedError = new NegatedAssertionError({ id: 'test' });
+      const assertionError = new AssertionError({ id: 'test' });
 
       expect(
         NegatedAssertionError.isNegatedAssertionError(negatedError),
@@ -344,8 +353,8 @@ describe('Error classes', () => {
 
   describe('Error inheritance relationships', () => {
     it('should maintain proper inheritance chain for AssertionError variants', () => {
-      const failError = new FailAssertionError({});
-      const negatedError = new NegatedAssertionError({});
+      const failError = new FailAssertionError();
+      const negatedError = new NegatedAssertionError({ id: 'test' });
 
       expect(failError, 'to be an instance of', AssertionError);
       expect(failError, 'to be an instance of', NodeAssertionError);
@@ -399,13 +408,13 @@ describe('Error classes', () => {
 
     it('should have correct names for all error classes', () => {
       const errors = {
-        assertionError: new AssertionError({}),
+        assertionError: new AssertionError({ id: 'test' }),
         asyncError: new UnexpectedAsyncError('test'),
         bupkisError: new BupkisError('test'),
-        failError: new FailAssertionError({}),
+        failError: new FailAssertionError(),
         implError: new AssertionImplementationError('test'),
         metadataError: new InvalidMetadataError('test'),
-        negatedError: new NegatedAssertionError({}),
+        negatedError: new NegatedAssertionError({ id: 'test' }),
         satisfactionError: new SatisfactionError('test'),
         schemaError: new InvalidObjectSchemaError('test'),
         unknownError: new UnknownAssertionError('test', { args: [] }),

--- a/test/property/value-to-schema.test.ts
+++ b/test/property/value-to-schema.test.ts
@@ -456,6 +456,22 @@ describe('valueToSchema() property tests', () => {
     );
   });
 
+  it.skip('should handle Map types', () => {
+    // this fails because valueToSchema does not traverse Maps or Sets
+    fc.assert(
+      fc.property(
+        fc
+          .tuple(filteredAnything, filteredAnything)
+          .map(([k, v]) => [new Map([[k, v]]), new Map([[v, k]])]),
+        ([map1, map2]) => {
+          const schema = valueToSchema(map2);
+          const result = schema.safeParse(map1);
+          return !!result.error;
+        },
+      ),
+    );
+  });
+
   it('should reject wrong types for built-in objects', () => {
     fc.assert(
       fc.property(fc.date(), fc.string(), (date, string) => {


### PR DESCRIPTION
chore(test): remove unnecessary return type signatures

chore(errors): all AssertionErrors now contain an assertionId property

chore(wallaby): exclude test harnesses from coverage

chore(test): tweaks

fix(assertions): another fix for handling of conjuncted assertions w/ bare "and" phrases