### PR TITLE
chore: add benchmarks w/ tinybench

### DIFF
--- a/.config/tsconfig.eslint.json
+++ b/.config/tsconfig.eslint.json
@@ -8,6 +8,8 @@
   "include": [
     "../src/**/*.ts",
     "../test/**/*.ts",
+    "../test-data/**/*.ts",
+    "../bench/**/*.ts",
     "../.wallaby.js",
     "../eslint.config.js",
     "../.commitlintrc.js",

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,175 @@
+# Bupkis Performance Benchmarks
+
+This directory contains comprehensive performance benchmarks for the Bupkis assertion library, providing detailed performance analysis and monitoring capabilities using [tinybench](https://npm.im/tinybench).
+
+## Overview
+
+The benchmark system monitors performance across multiple dimensions:
+
+1. **Traditional Categorical Benchmarks** - Group assertions by functionality (type, collection, comparison, pattern)
+2. **Implementation Class Benchmarks** - Group assertions by their implementation classes for performance comparison
+3. **Comprehensive Analysis** - Overall performance overview with implementation distribution
+
+## Files Overview
+
+- **`index.ts`** - Main benchmark suite with comprehensive assertion tests
+- **`config.ts`** - Configuration utilities, test data generators, and performance thresholds
+- **`suites.ts`** - Traditional categorical benchmark suites organized by assertion functionality
+- **`comprehensive-suites.ts`** - **NEW** Implementation class-based benchmarks for ALL assertions
+- **`runner.ts`** - CLI runner for executing different benchmark suites and modes
+
+## Available Scripts
+
+```bash
+# Run the main benchmark suite
+npm run bench
+
+# Run benchmarks in watch mode for development
+npm run bench:dev
+
+# Run the CLI benchmark runner
+npm run bench:runner
+
+# Quick performance check across all implementation types
+npm run bench:runner -- --mode quick --suite comprehensive
+
+# Specific implementation class benchmarks
+npm run bench:runner -- --suite sync-function    # 73 function-based sync assertions
+npm run bench:runner -- --suite sync-schema      # 44 schema-based sync assertions
+npm run bench:runner -- --suite async-function   # 10 function-based async assertions
+
+# Traditional categorical suites
+npm run bench:runner -- --suite type collection comparison pattern
+
+# Different benchmark modes
+npm run bench:runner -- --mode quick         # Fast iteration (development)
+npm run bench:runner -- --mode default       # Balanced accuracy
+npm run bench:runner -- --mode comprehensive # High accuracy (CI/production)
+```
+
+## Benchmark Suites
+
+### 🆕 Implementation Class Suites
+
+These suites benchmark **ALL assertions** grouped by their implementation classes, providing insights into the performance characteristics of different assertion architectures:
+
+#### **`comprehensive`** - Complete Analysis
+
+- Assertion Implementation Distribution:
+  - Sync Function-based: 73 assertions
+  - Sync Schema-based: 44 assertions
+  - Async Function-based: 10 assertions
+  - Async Schema-based: 0 assertions
+  - **Total: 127 assertions**
+
+#### **`sync-function`** - Function-based Sync Assertions
+
+- Tests assertions that use callback functions for validation
+- Example task names: `"{unknown} 'to be an instance of' / 'to be a' / 'to be an' {constructible}" [sync-function]`
+
+#### **`sync-schema`** - Schema-based Sync Assertions
+
+- Tests assertions that use Zod schemas for validation
+- Generally faster than function-based equivalents
+- Example: `"{unknown} 'to be a string'" [sync-schema]`
+
+#### **`async-function`** - Function-based Async Assertions
+
+- Tests Promise-based assertions with callback functions
+- Includes reject/resolve patterns with parameter validation
+
+#### **`async-schema`** - Schema-based Async Assertions
+
+- Currently no async schema-based assertions in the codebase
+
+### Traditional Categorical Suites
+
+#### **Type Assertions (`type`)**
+
+- Basic type checking assertions (string, number, boolean, etc.)
+- Focuses on the fundamental assertion building blocks
+
+### Collection Assertions (`collection`)
+
+- Array and object operations (contains, length, keys, etc.)
+- Tests performance with different collection sizes
+
+### Comparison Assertions (`comparison`)
+
+- Equality, inequality, and relational comparisons
+- Number and string comparisons
+
+### Pattern Assertions (`pattern`)
+
+- Regular expression matching
+- String pattern operations (startsWith, endsWith, includes)
+
+## Performance Thresholds
+
+The benchmark system includes configurable performance thresholds:
+
+- **Basic assertions**: 1.0ms threshold
+- **Collection operations**: 2.0ms threshold
+- **Comparison operations**: 1.5ms threshold
+- **Complex operations**: 5.0ms threshold
+- **Regex operations**: 3.0ms threshold
+
+Benchmarks that exceed these thresholds will generate performance warnings.
+
+## Configuration Modes
+
+### Quick Mode
+
+- 50 iterations, 500ms time limit
+- 5 warmup iterations, 50ms warmup time
+- Ideal for rapid development feedback
+
+### Default Mode
+
+- 100 iterations, 1000ms time limit
+- 10 warmup iterations, 100ms warmup time
+- Balanced accuracy and speed
+
+### Comprehensive Mode
+
+- 200 iterations, 2000ms time limit
+- 20 warmup iterations, 200ms warmup time
+- Maximum accuracy for CI/CD and release validation
+
+## Test Data Generators
+
+The `TEST_DATA` object provides consistent test data:
+
+- `simpleObject()` - Basic 3-property object
+- `nestedObject()` - Complex user object with nested properties
+- `largeArray(size)` - Configurable large array for stress testing
+- `deepObject()` - Deeply nested object (4 levels)
+- `stringArray()` - Array of fruit names for string operations
+- `mixedArray()` - Array with mixed data types
+
+## Usage in CI/CD
+
+For continuous integration, use comprehensive mode to catch performance regressions:
+
+```bash
+npm run bench:runner -- --mode comprehensive
+```
+
+The benchmarks will exit with a non-zero code if any performance thresholds are exceeded.
+
+## Adding New Benchmarks
+
+1. **Add to existing suite**: Modify the appropriate function in `suites.ts`
+2. **Create new suite**: Add a new create function in `suites.ts` and update `runner.ts`
+3. **Update main benchmark**: Add cases to `index.ts` for the comprehensive overview
+
+## Performance Monitoring
+
+The benchmark system is designed to help monitor:
+
+- **Performance regressions** between releases
+- **Scaling behavior** with different data sizes
+- **Assertion category performance** to identify bottlenecks
+- **Development impact** of code changes
+
+Use the benchmark results to ensure Bupkis maintains excellent performance characteristics across all assertion types.

--- a/bench/comprehensive-suites.ts
+++ b/bench/comprehensive-suites.ts
@@ -1,0 +1,397 @@
+/**
+ * Comprehensive benchmark suites for bupkis assertion performance testing.
+ *
+ * This module provides benchmarks for ALL assertions grouped by their
+ * implementation classes, allowing for targeted performance analysis of
+ * function-based vs schema assertions and sync vs async execution.
+ */
+
+import fc from 'fast-check';
+import { Bench } from 'tinybench';
+
+import {
+  BupkisAssertionFunctionAsync,
+  BupkisAssertionSchemaAsync,
+} from '../src/assertion/assertion-async.js';
+import {
+  BupkisAssertionFunctionSync,
+  BupkisAssertionSchemaSync,
+} from '../src/assertion/assertion-sync.js';
+import {
+  type AnyAssertion,
+  AsyncAssertions,
+  SyncAssertions,
+} from '../src/assertion/index.js';
+import { expect, expectAsync } from '../src/index.js';
+import {
+  AsyncParametricGenerators,
+  SyncBasicGenerators,
+  SyncCollectionGenerators,
+  SyncDateGenerators,
+  SyncEsotericGenerators,
+  SyncParametricGenerators,
+} from '../test-data/index.js';
+import { type GeneratorParams } from '../test/property/property-test-config.js';
+import { DEFAULT_BENCH_CONFIG } from './config.js';
+
+/**
+ * Configuration for benchmark creation
+ */
+interface BenchmarkConfig {
+  assertions: readonly AnyAssertion[];
+  filter: (assertion: AnyAssertion) => boolean;
+  label: string;
+  name: string;
+  taskRunner: (
+    assertion: AnyAssertion,
+    testData: unknown[],
+  ) => Promise<void> | void;
+}
+
+/**
+ * Factory function to create event handlers with timeout management
+ */
+const createEventHandlers = (benchmarkName: string) => {
+  const taskTimeouts = new Map<string, NodeJS.Timeout>();
+
+  const startHandler = () => {
+    console.log(`🏗️  Starting ${benchmarkName} benchmark...`);
+  };
+
+  const cycleHandler = (evt: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const task = evt.task as { name: string; result?: { hz?: number } };
+
+    // Clear timeout for this task
+    const timeout = taskTimeouts.get(task.name);
+    if (timeout) {
+      clearTimeout(timeout);
+      taskTimeouts.delete(task.name);
+    }
+
+    // Parse the task name to extract assertion title and collection
+    const match = task.name.match(/^(.+?)\s+\[(.+?)\]$/);
+    if (match) {
+      const [, assertionTitle, collection] = match;
+      const opsPerSec = task.result?.hz?.toFixed(0) ?? '?';
+      console.log(
+        `✓ \x1b[92m${assertionTitle}\x1b[0m \x1b[2m[${collection}]\x1b[0m: \x1b[33m${opsPerSec} ops/sec\x1b[0m`,
+      );
+    } else {
+      // Fallback for unexpected format
+      console.log(
+        `✓ ${task.name}: \x1b[33m${task.result?.hz?.toFixed(0) ?? '?'} ops/sec\x1b[0m`,
+      );
+    }
+  };
+
+  const completeHandler = () => {
+    console.log(`🏁 ${benchmarkName} benchmark complete!\n`);
+    // Clear any remaining timeouts
+    for (const timeout of taskTimeouts.values()) {
+      clearTimeout(timeout);
+    }
+    taskTimeouts.clear();
+  };
+
+  const createTaskTimeout = (taskName: string) => {
+    const timeout = setTimeout(() => {
+      const error = new Error(
+        `Benchmark timeout: Task "${taskName}" took longer than 10 seconds to complete. This may indicate a hanging assertion or infinite loop.`,
+      );
+      console.error(`\n⚠️  \x1b[31mTimeout Error:\x1b[0m ${error.message}`);
+      throw error;
+    }, 10000);
+    timeout.unref(); // Don't keep the process alive
+    taskTimeouts.set(taskName, timeout);
+  };
+
+  return {
+    completeHandler,
+    createTaskTimeout,
+    cycleHandler,
+    startHandler,
+    taskTimeouts,
+  };
+};
+
+/**
+ * Factory function to create a benchmark with standardized setup
+ */
+const createBenchmark = (config: BenchmarkConfig): Bench => {
+  const bench = new Bench(DEFAULT_BENCH_CONFIG);
+  const handlers = createEventHandlers(config.name);
+
+  // Set up event listeners
+  bench.addEventListener('start', handlers.startHandler);
+  bench.addEventListener('cycle', handlers.cycleHandler);
+  bench.addEventListener('complete', () => {
+    handlers.completeHandler();
+    // Clean up event listeners
+    bench.removeEventListener('start', handlers.startHandler);
+    bench.removeEventListener('cycle', handlers.cycleHandler);
+    bench.removeEventListener('complete', handlers.completeHandler);
+  });
+
+  const filteredAssertions = config.assertions.filter(config.filter);
+  console.log(`Benchmarking ${filteredAssertions.length} ${config.label}`);
+
+  // Add benchmarks for each assertion
+  for (const assertion of filteredAssertions) {
+    const phrase = getPrimaryPhrase(assertion);
+
+    if (phrase) {
+      const testData = getTestDataForAssertion(assertion);
+      const taskName = `${assertion} [${config.name}]`;
+
+      const task = bench.add(taskName, () =>
+        config.taskRunner(assertion, [...testData]),
+      );
+
+      // Add timeout handling for individual tasks
+      task.addEventListener('start', () => {
+        handlers.createTaskTimeout(taskName);
+      });
+    }
+  }
+
+  return bench;
+};
+
+/**
+ * Combined assertion arbitraries from all generator maps
+ */
+const assertionArbitraries = new Map<AnyAssertion, GeneratorParams>();
+// Combine all generator maps
+for (const [assertion, generators] of SyncBasicGenerators) {
+  assertionArbitraries.set(assertion, generators);
+}
+for (const [assertion, generators] of SyncCollectionGenerators) {
+  assertionArbitraries.set(assertion, generators);
+}
+for (const [assertion, generators] of SyncDateGenerators) {
+  assertionArbitraries.set(assertion, generators);
+}
+for (const [assertion, generators] of SyncEsotericGenerators) {
+  assertionArbitraries.set(assertion, generators);
+}
+for (const [assertion, generators] of SyncParametricGenerators) {
+  assertionArbitraries.set(assertion, generators);
+}
+for (const [assertion, generators] of AsyncParametricGenerators) {
+  assertionArbitraries.set(assertion, generators);
+}
+
+/**
+ * Type guard to check if assertion is a sync function-based implementation
+ */
+const isSyncFunctionAssertion = <T extends AnyAssertion>(
+  assertion: T,
+): assertion is BupkisAssertionFunctionSync<any, any, any> & T =>
+  assertion instanceof BupkisAssertionFunctionSync;
+
+/**
+ * Type guard to check if assertion is a sync schema-based implementation
+ */
+const isSyncSchemaAssertion = <T extends AnyAssertion>(
+  assertion: T,
+): assertion is BupkisAssertionSchemaSync<any, any, any> & T =>
+  assertion instanceof BupkisAssertionSchemaSync;
+
+/**
+ * Type guard to check if assertion is an async function-based implementation
+ */
+const isAsyncFunctionAssertion = <T extends AnyAssertion>(
+  assertion: T,
+): assertion is BupkisAssertionFunctionAsync<any, any, any> & T =>
+  assertion instanceof BupkisAssertionFunctionAsync;
+
+/**
+ * Type guard to check if assertion is an async schema-based implementation
+ */
+const _isAsyncSchemaAssertion = <T extends AnyAssertion>(
+  assertion: T,
+): assertion is BupkisAssertionSchemaAsync<any, any, any> & T =>
+  assertion instanceof BupkisAssertionSchemaAsync;
+
+/**
+ * Extract the primary phrase from assertion parts
+ */
+const getPrimaryPhrase = (assertion: AnyAssertion): null | string => {
+  const parts = assertion.parts as unknown[];
+
+  // Try each part until we find a string or string array
+  for (const part of parts) {
+    if (typeof part === 'string') {
+      return part;
+    }
+    if (Array.isArray(part) && part.length > 0 && typeof part[0] === 'string') {
+      return part[0];
+    }
+  }
+
+  throw new Error(
+    `Could not determine primary phrase for assertion ${assertion}`,
+  );
+};
+
+/**
+ * Type guard to check if generators is an array of arbitraries
+ */
+const isGeneratorArray = (
+  generators: any,
+): generators is readonly [
+  subject: fc.Arbitrary<any>,
+  phrase: fc.Arbitrary<string>,
+  ...fc.Arbitrary<any>[],
+] => Array.isArray(generators);
+
+/**
+ * Get generator params for an assertion that can be sampled and spread to
+ * expect/expectAsync.
+ *
+ * Ideally, this would return the exact Parts type for each assertion, but due
+ * to fast-check's typing limitations and the complexity of assertion type
+ * inference, we return a well-typed tuple structure that matches the expected
+ * signature for expect/expectAsync.
+ *
+ * @param assertion - The assertion to get test data for
+ * @returns Test data tuple matching the assertion's expected arguments
+ */
+const getTestDataForAssertion = (
+  assertion: AnyAssertion,
+): readonly [subject: unknown, phrase: string, ...unknown[]] => {
+  const generators = assertionArbitraries.get(assertion);
+
+  if (generators) {
+    if (isGeneratorArray(generators)) {
+      // Convert array format to tuple and sample
+      const sample = fc.sample(fc.tuple(...generators), 1)[0];
+      if (!sample) {
+        throw new Error(`Failed to sample generators for ${assertion}`);
+      }
+      return sample;
+    } else {
+      // Sample tuple format directly
+      const sample = fc.sample(generators, 1)[0];
+      if (!sample) {
+        throw new Error(`Failed to sample generators for ${assertion}`);
+      }
+      return sample;
+    }
+  }
+  throw new Error(`No generator found for assertion ${assertion}`);
+};
+
+/**
+ * Determines if an assertion is expected to throw/reject based on its phrase.
+ * These assertions test error conditions and throwing is their normal
+ * behavior.
+ */
+const isThrowingAssertion = (assertion: AnyAssertion): boolean => {
+  const phrase = getPrimaryPhrase(assertion);
+  if (!phrase) {
+    return false;
+  }
+
+  // List of phrases that indicate the assertion is meant to test error conditions
+  const throwingPatterns = [
+    'to throw',
+    'throws',
+    'to reject',
+    'rejects',
+    'to be rejected',
+    'to fail',
+    'fails',
+  ];
+
+  return throwingPatterns.some((pattern) =>
+    phrase.toLowerCase().includes(pattern),
+  );
+};
+
+/**
+ * Warns about unexpected exceptions during benchmarking. Only warns for
+ * assertions that aren't expected to throw.
+ */
+const warnUnexpectedException = (
+  assertion: AnyAssertion,
+  error: unknown,
+): void => {
+  if (!isThrowingAssertion(assertion)) {
+    console.warn(
+      `⚠️  Unexpected exception in benchmark for ${assertion}:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+};
+
+/**
+ * Create benchmarks for sync function-based assertions. Tests assertions that
+ * use callback functions for validation.
+ */
+export const createSyncFunctionAssertionsBench = (): Bench =>
+  createBenchmark({
+    assertions: SyncAssertions,
+    filter: isSyncFunctionAssertion,
+    label: 'sync function-based assertions',
+    name: 'sync-function',
+    taskRunner: (assertion, testData) => {
+      try {
+        expect(...testData);
+      } catch (error) {
+        warnUnexpectedException(assertion, error);
+      }
+    },
+  });
+
+/**
+ * Create benchmarks for sync schema-based assertions. Tests assertions that use
+ * Zod schemas for validation.
+ */
+export const createSyncSchemaAssertionsBench = (): Bench =>
+  createBenchmark({
+    assertions: SyncAssertions,
+    filter: isSyncSchemaAssertion,
+    label: 'sync schema-based assertions',
+    name: 'sync-schema',
+    taskRunner: (assertion, testData) => {
+      try {
+        expect(...testData);
+      } catch (error) {
+        warnUnexpectedException(assertion, error);
+      }
+    },
+  });
+
+/**
+ * Create benchmarks for async function-based assertions. Tests assertions that
+ * use callback functions for Promise validation.
+ */
+export const createAsyncFunctionAssertionsBench = (): Bench =>
+  createBenchmark({
+    assertions: AsyncAssertions,
+    filter: isAsyncFunctionAssertion,
+    label: 'async function-based assertions',
+    name: 'async-function',
+    taskRunner: async (assertion, testData) => {
+      try {
+        const phrase = getPrimaryPhrase(assertion);
+        if (!phrase) {
+          return;
+        }
+
+        // For async assertions, wrap the subject in a Promise
+        const promiseData = phrase.includes('reject')
+          ? Promise.reject(new Error(String(testData[0])))
+          : Promise.resolve(testData[0]);
+
+        // Create updated test data with the Promise as the first argument
+        const asyncTestData = [promiseData, ...testData.slice(1)];
+
+        await expectAsync(...asyncTestData);
+      } catch (error) {
+        warnUnexpectedException(assertion, error);
+      }
+    },
+  });

--- a/bench/config.ts
+++ b/bench/config.ts
@@ -1,0 +1,174 @@
+/**
+ * Benchmark configuration and utilities for Bupkis.
+ *
+ * This module provides common configuration and helper functions for all
+ * benchmark suites.
+ */
+
+import type { Options } from 'tinybench';
+
+/**
+ * Default benchmark configuration optimized for assertion testing.
+ */
+export const DEFAULT_BENCH_CONFIG: Options = {
+  iterations: 100,
+  time: 1000,
+  warmupIterations: 10,
+  warmupTime: 100,
+};
+
+/**
+ * Configuration for quick/development benchmarks.
+ */
+export const QUICK_BENCH_CONFIG: Options = {
+  iterations: 50,
+  time: 500,
+  warmupIterations: 5,
+  warmupTime: 50,
+};
+
+/**
+ * Configuration for comprehensive/CI benchmarks.
+ */
+export const COMPREHENSIVE_BENCH_CONFIG: Options = {
+  iterations: 200,
+  time: 2000,
+  warmupIterations: 20,
+  warmupTime: 200,
+};
+
+/**
+ * Configuration optimized for CI environments with limited resources. Focuses
+ * on relative performance and consistency over absolute numbers.
+ */
+export const CI_BENCH_CONFIG: Options = {
+  iterations: 30,
+  // Longer settling time for virtualized environments
+  setup: () => new Promise((resolve) => setTimeout(resolve, 100)),
+  time: 1000,
+  warmupIterations: 5,
+  warmupTime: 100,
+};
+
+/**
+ * Performance thresholds for different types of assertions (in milliseconds).
+ */
+export const PERFORMANCE_THRESHOLDS = {
+  basic: 1.0, // Basic type checks
+  collection: 2.0, // Array/object operations
+  comparison: 1.5, // Equality, inequality assertions
+  complex: 5.0, // Complex nested operations
+  regex: 3.0, // Regular expression matching
+} as const;
+
+/**
+ * Test data generators for consistent benchmarking.
+ */
+export const TEST_DATA = {
+  deepObject: () => ({
+    level1: {
+      level2: {
+        level3: {
+          level4: {
+            value: 'deep value',
+          },
+        },
+      },
+    },
+  }),
+
+  largeArray: (size = 1000) => Array.from({ length: size }, (_, i) => i),
+
+  mixedArray: () => [1, 'string', true, null, { key: 'value' }],
+
+  nestedObject: () => ({
+    user: {
+      emails: ['user@example.com', 'user@work.com'],
+      id: 123,
+      name: 'Test User',
+      settings: { notifications: true, theme: 'dark' },
+    },
+  }),
+
+  simpleObject: () => ({ a: 1, b: 2, c: 3 }),
+
+  stringArray: () => ['apple', 'banana', 'cherry', 'date', 'elderberry'],
+} as const;
+
+/**
+ * Helper function to format benchmark results for consistent output.
+ */
+export interface BenchmarkResult {
+  average: number;
+  max: number;
+  min: number;
+  name: string;
+  opsPerSec: number;
+  standardDeviation: number;
+}
+
+/**
+ * Extracts and formats benchmark results from tinybench tasks.
+ */
+export const formatResults = (
+  tasks: Array<{
+    name: string;
+    result?: {
+      max?: number;
+      mean?: number;
+      min?: number;
+      sd?: number;
+    };
+  }>,
+): BenchmarkResult[] => {
+  return tasks.map((task) => ({
+    average: (task.result?.mean as number) ?? 0,
+    max: (task.result?.max as number) ?? 0,
+    min: (task.result?.min as number) ?? 0,
+    name: task.name,
+    opsPerSec: Math.round(1000 / ((task.result?.mean as number) ?? 1)),
+    standardDeviation: (task.result?.sd as number) ?? 0,
+  }));
+};
+
+/**
+ * Checks results against performance thresholds and returns warnings.
+ */
+export const checkPerformance = (
+  results: BenchmarkResult[],
+  thresholds: Record<string, number> = PERFORMANCE_THRESHOLDS,
+): { passed: boolean; warnings: string[] } => {
+  const warnings: string[] = [];
+
+  for (const result of results) {
+    // Simple heuristic to categorize benchmark types
+    let threshold = thresholds.basic;
+
+    if (result.name.includes('complex') || result.name.includes('nested')) {
+      threshold = thresholds.complex;
+    } else if (
+      result.name.includes('array') ||
+      result.name.includes('object')
+    ) {
+      threshold = thresholds.collection;
+    } else if (result.name.includes('match') || result.name.includes('regex')) {
+      threshold = thresholds.regex;
+    } else if (
+      result.name.includes('equal') ||
+      result.name.includes('comparison')
+    ) {
+      threshold = thresholds.comparison;
+    }
+
+    if (threshold !== undefined && result.average > threshold) {
+      warnings.push(
+        `${result.name}: ${result.average.toFixed(2)}ms (threshold: ${threshold}ms)`,
+      );
+    }
+  }
+
+  return {
+    passed: warnings.length === 0,
+    warnings,
+  };
+};

--- a/bench/index.ts
+++ b/bench/index.ts
@@ -1,0 +1,101 @@
+/**
+ * Performance benchmarks for Bupkis assertion library.
+ *
+ * This module sets up and runs benchmarks to monitor performance
+ * characteristics of the assertion library, helping identify performance
+ * regressions and optimization opportunities.
+ */
+
+import { Bench } from 'tinybench';
+
+import { expect } from '../src/index.js';
+import {
+  checkPerformance,
+  DEFAULT_BENCH_CONFIG,
+  formatResults,
+  TEST_DATA,
+} from './config.js';
+
+// Create a benchmark suite
+const bench = new Bench(DEFAULT_BENCH_CONFIG);
+
+// Basic assertion benchmarks
+bench
+  .add('Basic type assertion - string', () => {
+    expect('hello', 'to be a string');
+  })
+  .add('Basic type assertion - number', () => {
+    expect(42, 'to be a number');
+  })
+  .add('Basic type assertion - boolean', () => {
+    expect(true, 'to be a boolean');
+  })
+  .add('Basic equality assertion', () => {
+    expect('hello', 'to equal', 'hello');
+  })
+  .add('Array contains assertion', () => {
+    expect([1, 2, 3, 4, 5], 'to contain', 3);
+  })
+  .add('Object property assertion', () => {
+    expect(TEST_DATA.simpleObject(), 'to have key', 'b');
+  })
+  .add('String matching assertion', () => {
+    expect('hello world', 'to match', /world/);
+  })
+  .add('Complex nested object assertion', () => {
+    expect(TEST_DATA.nestedObject(), 'to have key', 'user.name');
+  })
+  .add('Large array contains assertion', () => {
+    expect(TEST_DATA.largeArray(100), 'to contain', 50);
+  })
+  .add('Deep object property assertion', () => {
+    expect(
+      TEST_DATA.deepObject(),
+      'to have key',
+      'level1.level2.level3.level4.value',
+    );
+  });
+
+// Run the benchmarks
+const runBenchmarks = async (): Promise<void> => {
+  console.log('🚀 Running Bupkis performance benchmarks...\n');
+
+  await bench.run();
+
+  console.log('\n📊 Benchmark Results:');
+  console.table(bench.table());
+
+  // Use the formatting utilities
+  const results = formatResults(bench.tasks);
+  const performanceCheck = checkPerformance(results);
+
+  // Log additional statistics
+  console.log('\n📈 Detailed Results:');
+  for (const result of results) {
+    console.log(`\n${result.name}:`);
+    console.log(`  Average: ${result.average.toFixed(2)}ms`);
+    console.log(`  Ops/sec: ${result.opsPerSec}`);
+    console.log(`  Min: ${result.min.toFixed(2)}ms`);
+    console.log(`  Max: ${result.max.toFixed(2)}ms`);
+    console.log(
+      `  Standard Deviation: ${result.standardDeviation.toFixed(2)}ms`,
+    );
+  }
+
+  // Performance check results
+  if (performanceCheck.passed) {
+    console.log('\n✅ All benchmarks performed within acceptable limits!');
+  } else {
+    console.log('\n⚠️  Performance Warning:');
+    console.log('The following tasks exceeded performance thresholds:');
+    for (const warning of performanceCheck.warnings) {
+      console.log(`  - ${warning}`);
+    }
+  }
+};
+
+// Error handling
+runBenchmarks().catch((error) => {
+  console.error('❌ Benchmark failed:', error);
+  process.exit(1);
+});

--- a/bench/runner.ts
+++ b/bench/runner.ts
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+/**
+ * Comprehensive benchmark runner for Bupkis.
+ *
+ * This script provides a CLI interface for running different benchmark suites
+ * and modes, useful for CI/CD and development.
+ */
+
+import type { BenchMode } from './suites.js';
+
+import {
+  createAsyncFunctionAssertionsBench,
+  createSyncFunctionAssertionsBench,
+  createSyncSchemaAssertionsBench,
+} from './comprehensive-suites.js';
+import {
+  createCollectionAssertionsBench,
+  createComparisonAssertionsBench,
+  createPatternAssertionsBench,
+  createTypeAssertionsBench,
+  runBenchmarkSuite,
+} from './suites.js';
+
+// // Handle SIGINT (Ctrl+C) and SIGTERM gracefully
+// let isShuttingDown = false;
+
+// const gracefulShutdown = (signal: string) => {
+//   if (isShuttingDown) {
+//     console.log('\n\n💀 \x1b[31mForce killing process...\x1b[0m');
+//     process.exit(1);
+//   }
+
+//   isShuttingDown = true;
+//   console.log(
+//     `\n\n🛑 \x1b[33mBenchmark interrupted by ${signal} signal (Ctrl+C)\x1b[0m`,
+//   );
+//   console.log('🧹 \x1b[2mCleaning up and exiting...\x1b[0m');
+
+//   // Give a brief moment for cleanup, then force exit
+//   setTimeout(() => {
+//     console.log('⚡ \x1b[31mForce exiting after timeout\x1b[0m');
+//     process.exit(1);
+//   }, 1000);
+
+//   process.exit(0);
+// };
+
+interface RunnerOptions {
+  mode: BenchMode;
+  suites: string[];
+}
+
+/**
+ * Available benchmark suites.
+ */
+const AVAILABLE_SUITES = {
+  all: 'Run all benchmark suites',
+  'async-function': 'Async function-based assertions',
+  collection: 'Array and object assertions',
+  comparison: 'Equality and comparison assertions',
+  pattern: 'Pattern matching and regex assertions',
+  'sync-function': 'Sync function-based assertions',
+  'sync-schema': 'Sync schema-based assertions',
+  type: 'Basic type checking assertions',
+} as const;
+
+/**
+ * Parse command line arguments.
+ */
+const parseArgs = (): RunnerOptions => {
+  const args = process.argv.slice(2);
+
+  let mode: BenchMode = 'default';
+  let suites: string[] = ['all'];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--mode' && i + 1 < args.length) {
+      const modeArg = args[i + 1] as BenchMode;
+      if (
+        modeArg === 'ci' ||
+        modeArg === 'quick' ||
+        modeArg === 'default' ||
+        modeArg === 'comprehensive'
+      ) {
+        mode = modeArg;
+      }
+      i++; // Skip next arg since we consumed it
+    } else if (arg === '--suite' && i + 1 < args.length) {
+      if (suites.includes('all')) {
+        suites = []; // Clear 'all' if specific suites are specified
+      }
+      const suite = args[i + 1];
+      if (suite) {
+        suites.push(suite);
+      }
+      i++; // Skip next arg since we consumed it
+    } else if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  return { mode, suites };
+};
+
+/**
+ * Print usage information.
+ */
+const printHelp = (): void => {
+  console.log(`
+Bupkis Benchmark Runner
+
+Usage: npm run bench:runner [options]
+
+Options:
+  --mode <mode>     Benchmark mode: quick, default, comprehensive, ci (default: default)
+  --suite <suite>   Specific suite to run (can be used multiple times)
+  --help           Show this help message
+
+Available suites:
+${Object.entries(AVAILABLE_SUITES)
+  .map(([key, desc]) => `  ${key.padEnd(12)} ${desc}`)
+  .join('\n')}
+
+Examples:
+  npm run bench:runner
+  npm run bench:runner -- --mode quick
+  npm run bench:runner -- --suite type --suite collection
+  npm run bench:runner -- --mode comprehensive --suite pattern
+  `);
+};
+
+/**
+ * Run the specified benchmark suites.
+ */
+const runBenchmarks = async (options: RunnerOptions): Promise<void> => {
+  console.log('🚀 Bupkis Performance Benchmark Runner');
+  console.log(`Mode: ${options.mode}`);
+  console.log(`Suites: ${options.suites.join(', ')}`);
+
+  const startTime = Date.now();
+
+  const suites: Promise<void>[] = [];
+
+  try {
+    if (options.suites.includes('all') || options.suites.includes('type')) {
+      suites.push(
+        runBenchmarkSuite(
+          'Type Assertions',
+          createTypeAssertionsBench,
+          options.mode,
+        ),
+      );
+    }
+
+    if (
+      options.suites.includes('all') ||
+      options.suites.includes('collection')
+    ) {
+      suites.push(
+        runBenchmarkSuite(
+          'Collection Assertions',
+          createCollectionAssertionsBench,
+          options.mode,
+        ),
+      );
+    }
+
+    if (
+      options.suites.includes('all') ||
+      options.suites.includes('comparison')
+    ) {
+      suites.push(
+        runBenchmarkSuite(
+          'Comparison Assertions',
+          createComparisonAssertionsBench,
+          options.mode,
+        ),
+      );
+    }
+
+    if (options.suites.includes('all') || options.suites.includes('pattern')) {
+      suites.push(
+        runBenchmarkSuite(
+          'Pattern Assertions',
+          createPatternAssertionsBench,
+          options.mode,
+        ),
+      );
+    }
+
+    // New comprehensive assertion benchmarks grouped by implementation
+    if (
+      options.suites.includes('all') ||
+      options.suites.includes('sync-function')
+    ) {
+      suites.push(
+        runBenchmarkSuite(
+          'Sync Function-based Assertions',
+          createSyncFunctionAssertionsBench,
+          options.mode,
+        ),
+      );
+    }
+
+    if (
+      options.suites.includes('all') ||
+      options.suites.includes('sync-schema')
+    ) {
+      suites.push(
+        runBenchmarkSuite(
+          'Sync Schema-based Assertions',
+          createSyncSchemaAssertionsBench,
+          options.mode,
+        ),
+      );
+    }
+
+    if (
+      options.suites.includes('all') ||
+      options.suites.includes('async-function')
+    ) {
+      suites.push(
+        runBenchmarkSuite(
+          'Async Function-based Assertions',
+          createAsyncFunctionAssertionsBench,
+          options.mode,
+        ),
+      );
+    }
+
+    await Promise.all(suites);
+
+    const endTime = Date.now();
+    const duration = (endTime - startTime) / 1000;
+
+    console.log(`\n✅ All benchmarks completed in ${duration.toFixed(2)}s`);
+  } catch (error) {
+    console.error('\n❌ Benchmark failed:', error);
+    process.exit(1);
+  }
+};
+
+// Main execution
+const main = async (): Promise<void> => {
+  const options = parseArgs();
+  await runBenchmarks(options);
+};
+
+// Run if this file is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });
+}

--- a/bench/suites.ts
+++ b/bench/suites.ts
@@ -1,0 +1,174 @@
+/**
+ * Specialized benchmark suites for different assertion categories.
+ *
+ * This module contains focused benchmark suites for specific types of
+ * assertions to help identify performance issues in particular areas.
+ */
+
+import { Bench } from 'tinybench';
+
+import { expect } from '../src/index.js';
+import {
+  CI_BENCH_CONFIG,
+  COMPREHENSIVE_BENCH_CONFIG,
+  DEFAULT_BENCH_CONFIG,
+  QUICK_BENCH_CONFIG,
+  TEST_DATA,
+} from './config.js';
+
+/**
+ * Benchmarks for basic type assertions.
+ */
+export const createTypeAssertionsBench = (
+  config = DEFAULT_BENCH_CONFIG,
+): Bench => {
+  const bench = new Bench(config);
+
+  return bench
+    .add('string type check', () => {
+      expect('hello', 'to be a string');
+    })
+    .add('number type check', () => {
+      expect(42, 'to be a number');
+    })
+    .add('boolean type check', () => {
+      expect(true, 'to be a boolean');
+    })
+    .add('array type check', () => {
+      expect([], 'to be an array');
+    })
+    .add('object type check', () => {
+      expect({}, 'to be an object');
+    })
+    .add('null type check', () => {
+      expect(null, 'to be null');
+    })
+    .add('undefined type check', () => {
+      expect(undefined, 'to be undefined');
+    });
+};
+
+/**
+ * Benchmarks for collection-based assertions.
+ */
+export const createCollectionAssertionsBench = (
+  config = DEFAULT_BENCH_CONFIG,
+): Bench => {
+  const bench = new Bench(config);
+
+  return bench
+    .add('array contains - small array', () => {
+      expect(TEST_DATA.stringArray(), 'to contain', 'cherry');
+    })
+    .add('array contains - large array', () => {
+      expect(TEST_DATA.largeArray(1000), 'to contain', 500);
+    })
+    .add('object has key - simple', () => {
+      expect(TEST_DATA.simpleObject(), 'to have key', 'b');
+    })
+    .add('object has key - nested', () => {
+      expect(TEST_DATA.nestedObject(), 'to have key', 'user.name');
+    })
+    .add('object has key - deep', () => {
+      expect(
+        TEST_DATA.deepObject(),
+        'to have key',
+        'level1.level2.level3.level4.value',
+      );
+    })
+    .add('array length check', () => {
+      expect(TEST_DATA.stringArray(), 'to have length', 5);
+    })
+    .add('object size check', () => {
+      expect(TEST_DATA.simpleObject(), 'to have size', 3);
+    });
+};
+
+/**
+ * Benchmarks for equality and comparison assertions.
+ */
+export const createComparisonAssertionsBench = (
+  config = DEFAULT_BENCH_CONFIG,
+): Bench => {
+  const bench = new Bench(config);
+
+  return bench
+    .add('string equality', () => {
+      expect('hello', 'to equal', 'hello');
+    })
+    .add('number equality', () => {
+      expect(42, 'to equal', 42);
+    })
+    .add('object equality', () => {
+      const obj = { a: 1, b: 2 };
+      expect(obj, 'to equal', obj);
+    })
+    .add('array equality', () => {
+      const arr = [1, 2, 3];
+      expect(arr, 'to equal', arr);
+    })
+    .add('number greater than', () => {
+      expect(10, 'to be greater than', 5);
+    })
+    .add('number less than', () => {
+      expect(5, 'to be less than', 10);
+    })
+    .add('string includes', () => {
+      expect('hello world', 'to include', 'world');
+    });
+};
+
+/**
+ * Benchmarks for pattern matching and regex assertions.
+ */
+export const createPatternAssertionsBench = (
+  config = DEFAULT_BENCH_CONFIG,
+): Bench => {
+  const bench = new Bench(config);
+
+  return bench
+    .add('simple regex match', () => {
+      expect('hello123', 'to match', /\d+/);
+    })
+    .add('complex regex match', () => {
+      expect('user@example.com', 'to match', /^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+    })
+    .add('string starts with', () => {
+      expect('hello world', 'to start with', 'hello');
+    })
+    .add('string ends with', () => {
+      expect('hello world', 'to end with', 'world');
+    })
+    .add('case-insensitive match', () => {
+      expect('Hello World', 'to match', /hello/i);
+    });
+};
+
+/**
+ * Configuration options for benchmark modes.
+ */
+export const BENCH_MODES = {
+  ci: CI_BENCH_CONFIG,
+  comprehensive: COMPREHENSIVE_BENCH_CONFIG,
+  default: DEFAULT_BENCH_CONFIG,
+  quick: QUICK_BENCH_CONFIG,
+} as const;
+
+export type BenchMode = keyof typeof BENCH_MODES;
+
+/**
+ * Run a specific benchmark suite.
+ */
+export const runBenchmarkSuite = async (
+  name: string,
+  createBench: (config?: any) => Bench,
+  mode: BenchMode = 'default',
+): Promise<void> => {
+  console.log(`\n🔧 Running ${name} benchmarks (${mode} mode)...`);
+
+  const bench = createBench(BENCH_MODES[mode]);
+  await bench.run();
+
+  console.log(`\n📊 ${name} Results:`);
+  console.table(bench.table());
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "prettier-plugin-pkg": "0.21.2",
         "prettier-plugin-sort-json": "4.1.1",
         "serve": "14.2.5",
+        "tinybench": "2.9.0",
         "tshy": "3.0.3",
         "tsx": "4.20.6",
         "typedoc": "0.28.13",
@@ -594,8 +595,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.18.tgz",
       "integrity": "sha512-EF77RqROHL+4LhMGW5NTeKqfUd/e4OOv6EDFQ/UQQiFyWuqkEKyEz0NDILxOFxWUEVdjT2GQ2cC7t12B6pESwg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.1",
@@ -735,16 +735,14 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.12.tgz",
       "integrity": "sha512-JFffQ1dDVEyJq6tCDWv0r/RqkdSnV43P2F/3jJ9rwLgdsOIXwQbXrz6QDlvQLVvNSnORH9KjDtenFTGDyzfCaA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.4.tgz",
       "integrity": "sha512-afea+0rGPDeOV9gdO06UW183Qg6wRhWVkgCFwiO3bDupAoyXRuvupbb5nUyqSTsLXIKL8u8uXQlJ9pkz07oVXw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -942,8 +940,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -2559,7 +2556,6 @@
       "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.13.0"
       }
@@ -2674,7 +2670,6 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -2874,7 +2869,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3895,7 +3889,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4689,7 +4682,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6694,7 +6686,6 @@
       "integrity": "sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -7115,7 +7106,6 @@
       "integrity": "sha512-/4Osri9QFGCZOCTkfA8qJF+XGjKYERSHkXzxSyS1hd3ZERJGjvsUao2h4wdnvpHp6Tu2Jh/bPHM0FE9JJza6ng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "globby": "14.1.0",
         "js-yaml": "4.1.0",
@@ -8492,7 +8482,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10120,6 +10109,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
@@ -10345,7 +10341,6 @@
       "integrity": "sha512-dNWY8msnYB2a+7Audha+aTF1Pu3euiE7ySp53w8kEsXoYw7dMouV5A1UsTUY345aB152RHnmRMDiovuBi7BD+w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.12.0",
         "lunr": "^2.3.9",
@@ -10420,7 +10415,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -116,6 +116,9 @@
     "tape"
   ],
   "scripts": {
+    "bench": "tsx bench/index.ts",
+    "bench:dev": "tsx --watch bench/index.ts",
+    "bench:runner": "tsx bench/runner.ts",
     "build": "tshy",
     "build:dev": "tshy --watch",
     "debug:assertion-ids": "tsx scripts/dump-assertion-ids.ts",
@@ -192,6 +195,7 @@
     "prettier-plugin-pkg": "0.21.2",
     "prettier-plugin-sort-json": "4.1.1",
     "serve": "14.2.5",
+    "tinybench": "2.9.0",
     "tshy": "3.0.3",
     "tsx": "4.20.6",
     "typedoc": "0.28.13",
@@ -225,6 +229,7 @@
     "node": {
       "entry": [
         ".config/typedoc-plugin-bupkis.js",
+        "bench/*.ts",
         "scripts/*.js",
         "scripts/*.ts",
         "test/**/*.test.ts",

--- a/test-data/README.md
+++ b/test-data/README.md
@@ -1,0 +1,273 @@
+# Test Data Generators
+
+This directory contains **fast-check arbitraries** for generating valid test data for all bupkis assertions. The test data is shared between **property-based tests** and **performance benchmarks**, ensuring consistency and correctness across the testing infrastructure.
+
+## Overview
+
+The test data generators serve two critical purposes:
+
+1. **Property-Based Testing**: Generate diverse, valid inputs for comprehensive property testing
+2. **Performance Benchmarking**: Provide realistic test data for accurate performance measurements
+
+## Architecture
+
+### Core Components
+
+- **Generator Maps**: Each file exports a `Map<AnyAssertion, GeneratorParams>` linking assertions to their test data generators
+- **Fast-Check Integration**: All generators use [fast-check][] arbitraries for deterministic, reproducible test data
+- **Type Safety**: TypeScript ensures generator outputs match assertion input requirements
+
+### File Structure
+
+```plain
+test-data/
+├── README.md                      # This documentation
+├── index.ts                       # Exports all generator maps
+├── sync-basic-generators.ts       # Basic type assertions (string, number, boolean, etc.)
+├── sync-collection-generators.ts  # Collection assertions (arrays, objects, Maps, Sets)
+├── sync-date-generators.ts        # Date-related assertions
+├── sync-esoteric-generators.ts    # Advanced assertions (instanceof, prototypes)
+├── sync-parametric-generators.ts  # Parameterized assertions (greater than, contains)
+└── async-parametric-generators.ts # Promise-based assertions
+```
+
+## Generator Types
+
+### `GeneratorParams`
+
+Generators can be defined in two formats:
+
+1. **Array Format**: Tuple of individual arbitraries
+
+   ```typescript
+   [
+     fc.string(), // Subject arbitrary
+     fc.constantFrom('to be a string'), // Phrase arbitrary
+     // ...additional parameter arbitraries
+   ];
+   ```
+
+2. **Tuple Format**: Single arbitrary producing complete argument tuple
+
+   ```typescript
+   fc.tuple(
+     fc.string(), // Subject
+     fc.constantFrom('to be a string'), // Phrase
+     // ...additional parameters
+   );
+   ```
+
+### Example Generator
+
+```typescript
+// Basic string assertion generator
+[
+  assertions.stringAssertion,
+  [
+    fc.string(),                                    // Generate string subjects
+    fc.constantFrom(...extractPhrases(assertions.stringAssertion)), // Valid phrases
+  ],
+]
+
+// Parametric comparison generator
+[
+  assertions.greaterThanAssertion,
+  [
+    fc.integer(),                                   // Subject number
+    fc.constantFrom('to be greater than'),          // Phrase
+    fc.integer().map(n => n - 1),                   // Smaller comparison value
+  ],
+]
+```
+
+## Usage Patterns
+
+### In Property Tests
+
+Property tests use generators to create comprehensive test cases:
+
+```typescript
+// From property tests
+const generators = SyncBasicGenerators.get(assertion);
+if (generators) {
+  fc.assert(
+    fc.property(fc.tuple(...generators), (args) => {
+      // Test assertion with generated arguments
+      expect(...args);
+    }),
+  );
+}
+```
+
+### In Benchmarks
+
+Benchmarks sample generators for realistic performance testing:
+
+```typescript
+// From benchmarks
+const testData = getTestDataForAssertion(assertion);
+// testData is sampled from generators for consistent benchmarking
+bench.add(`${assertion} [sync-function]`, () => {
+  expect(...testData);
+});
+```
+
+## Generator Design Principles
+
+### 1. **Validity First**
+
+Generators produce valid inputs that should make assertions pass:
+
+```typescript
+// String length generator - ensures subject has the specified length
+[
+  assertions.lengthAssertion,
+  [
+    fc.string().chain((s) => fc.constant(s)), // Subject string
+    fc.constantFrom('to have length'), // Phrase
+    fc.string().map((s) => s.length), // Matching length
+  ],
+];
+```
+
+### 2. **Phrase Extraction**
+
+Uses `extractPhrases()` to get valid assertion phrases dynamically:
+
+```typescript
+fc.constantFrom(...extractPhrases(assertions.stringAssertion));
+// Produces: 'to be a string' (and any alternative phrases)
+```
+
+### 3. **Coordinated Generation**
+
+Complex assertions coordinate multiple parameters:
+
+```typescript
+// Range assertion - ensures subject is within the generated range
+[
+  assertions.withinAssertion,
+  fc
+    .tuple(
+      fc.integer(), // Subject
+      fc.constantFrom('to be within'), // Phrase
+      fc.integer(), // Min value
+      fc.integer(), // Max value
+    )
+    .chain(([subject, phrase, min, max]) => {
+      const [actualMin, actualMax] = [Math.min(min, max), Math.max(min, max)];
+      const validSubject = fc.integer({
+        min: actualMin,
+        max: actualMax,
+      });
+      return fc.constant([validSubject, phrase, actualMin, actualMax]);
+    }),
+];
+```
+
+### 4. **Filtered Generation**
+
+Uses utility functions for constrained generation:
+
+```typescript
+// From property-test-util.js
+filteredAnything; // Excludes problematic values (undefined, symbols, etc.)
+filteredObject; // Generates plain objects only
+filteredArray; // Generates arrays with filtered contents
+```
+
+## Generator Categories
+
+### Basic Type Generators (`sync-basic-generators.ts`)
+
+Test fundamental type checking assertions:
+
+- `stringAssertion` → Generates strings for `'to be a string'`
+- `numberAssertion` → Generates numbers for `'to be a number'`
+- `booleanAssertion` → Generates booleans for `'to be a boolean'`
+- `arrayAssertion` → Generates arrays for `'to be an array'`
+
+### Collection Generators (`sync-collection-generators.ts`)
+
+Test collection manipulation and querying:
+
+- `containsAssertion` → Generates arrays containing specific elements
+- `lengthAssertion` → Generates collections with specific lengths
+- `emptyAssertion` → Generates empty collections
+- `keyAssertion` → Generates objects with specific keys
+
+### Parametric Generators (`sync-parametric-generators.ts`)
+
+Test assertions requiring additional parameters:
+
+- `greaterThanAssertion` → Generates number/value + smaller comparison
+- `matchesAssertion` → Generates strings + matching RegExp patterns
+- `throwsAssertion` → Generates functions + expected error types
+
+### Async Generators (`async-parametric-generators.ts`)
+
+Test Promise-based assertions:
+
+- `resolvesAssertion` → Generates resolving Promises + expected values
+- `rejectsAssertion` → Generates rejecting Promises + expected errors
+
+## Integration Points
+
+### Property Test Integration
+
+The generators are consumed by property tests via:
+
+1. **Assertion Discovery**: Tests iterate over generator maps
+2. **Dynamic Test Generation**: Each assertion gets property tests auto-generated
+3. **Variant Testing**: Multiple test configurations per assertion type
+
+### Benchmark Integration
+
+The generators feed into benchmarks through:
+
+1. **Sampling**: `fc.sample()` extracts concrete test data
+2. **Consistency**: Same generators ensure benchmarks test realistic scenarios
+3. **Performance**: Pre-generated data avoids overhead during benchmarking
+
+### Example Integration Flow
+
+```mermaid
+graph TD
+    A[Generator Maps] --> B[Property Tests]
+    A --> C[Benchmark Tests]
+    B --> D[Comprehensive Validation]
+    C --> E[Performance Metrics]
+    D --> F[Confidence in Correctness]
+    E --> F
+```
+
+## Development Guidelines
+
+### Adding New Generators
+
+1. **Identify the assertion type** and target file
+2. **Design coordinated generation** ensuring validity
+3. **Use phrase extraction** for dynamic phrase selection
+4. **Test both positive and edge cases** where appropriate
+5. **Document complex generation strategies** with comments
+
+### Generator Quality Checklist
+
+- ✅ **Generates valid inputs** that make assertions pass
+- ✅ **Uses `extractPhrases()`** for phrase selection
+- ✅ **Coordinates parameters** when assertions have dependencies
+- ✅ **Handles edge cases** appropriately
+- ✅ **Avoids problematic values** using filtered generators
+- ✅ **Provides good coverage** of the assertion's domain
+
+## Fast-Check Resources
+
+- [Fast-Check Documentation][fast-check]
+- [Arbitrary API Reference](https://fast-check.dev/docs/core-blocks/arbitraries/)
+- [Property-Based Testing Guide](https://fast-check.dev/docs/introduction/getting-started/)
+
+---
+
+The test data infrastructure ensures that both property tests and benchmarks work with realistic, valid data, providing confidence in both **correctness** and **performance** measurements.
+
+[fast-check]: https://fast-check.dev

--- a/test-data/async-parametric-generators.ts
+++ b/test-data/async-parametric-generators.ts
@@ -1,0 +1,182 @@
+import escapeStringRegexp from 'escape-string-regexp';
+import fc from 'fast-check';
+
+import * as assertions from '../src/assertion/impl/async-parametric.js';
+import { type AnyAssertion } from '../src/types.js';
+import { type GeneratorParams } from '../test/property/property-test-config.js';
+import {
+  extractPhrases,
+  safeRegexStringFilter,
+} from '../test/property/property-test-util.js';
+
+export const AsyncParametricGenerators = new Map<AnyAssertion, GeneratorParams>(
+  [
+    [
+      assertions.functionFulfillWithValueSatisfyingAssertion,
+      fc
+        .string({ maxLength: 9, minLength: 7 })
+        .map(safeRegexStringFilter)
+        .filter((message) => !!message.length)
+        .chain((str) =>
+          fc.tuple(
+            fc.constant(async () => str),
+            fc.constantFrom(
+              ...extractPhrases(
+                assertions.functionFulfillWithValueSatisfyingAssertion,
+              ),
+            ),
+            fc.constant(str),
+          ),
+        ),
+    ],
+    [
+      assertions.functionRejectAssertion,
+      fc.string().chain((expected) =>
+        fc.tuple(
+          fc.constant(async () => {
+            throw new Error(expected);
+          }),
+          fc.constantFrom(
+            ...extractPhrases(assertions.functionRejectAssertion),
+          ),
+        ),
+      ),
+    ],
+    [
+      assertions.functionRejectWithErrorSatisfyingAssertion,
+      fc
+        .string({ maxLength: 5, minLength: 1 })
+        .map(safeRegexStringFilter)
+        .filter((actual) => !!actual.length)
+        .chain((expected) =>
+          fc.tuple(
+            fc.constant(async () => {
+              throw new Error(expected);
+            }),
+            fc.constantFrom(
+              ...extractPhrases(
+                assertions.functionRejectWithErrorSatisfyingAssertion,
+              ),
+            ),
+            fc.oneof(
+              fc.constant(expected),
+              fc.constant(new RegExp(escapeStringRegexp(expected))),
+              fc.constant({ message: expected }),
+              fc.constant({
+                message: new RegExp(escapeStringRegexp(expected)),
+              }),
+            ),
+          ),
+        ),
+    ],
+    [
+      assertions.functionRejectWithTypeAssertion,
+      fc
+        .constantFrom(TypeError, ReferenceError, RangeError, SyntaxError)
+        .chain((ErrorCtor) =>
+          fc.tuple(
+            fc.constant(async () => {
+              throw new ErrorCtor('error');
+            }),
+            fc.constantFrom(
+              ...extractPhrases(assertions.functionRejectWithTypeAssertion),
+            ),
+            fc.constant(ErrorCtor),
+          ),
+        ),
+    ],
+    [
+      assertions.functionResolveAssertion,
+      [
+        fc.constant(async () => 'success'),
+        fc.constantFrom(...extractPhrases(assertions.functionResolveAssertion)),
+      ],
+    ],
+    [
+      assertions.promiseRejectAssertion,
+      [
+        fc.constant({
+          then(_resolve: (value: any) => void, reject: (reason: any) => void) {
+            reject(new Error('rejection'));
+          },
+        }),
+        fc.constantFrom(...extractPhrases(assertions.promiseRejectAssertion)),
+      ],
+    ],
+    [
+      assertions.promiseRejectWithErrorSatisfyingAssertion,
+      fc.string().chain((message) =>
+        fc.tuple(
+          fc.constant({
+            then(
+              _resolve: (value: any) => void,
+              reject: (reason: any) => void,
+            ) {
+              reject(new Error(message));
+            },
+          }),
+          fc.constantFrom(
+            ...extractPhrases(
+              assertions.promiseRejectWithErrorSatisfyingAssertion,
+            ),
+          ),
+          fc.constant(message),
+        ),
+      ),
+    ],
+    [
+      assertions.promiseRejectWithTypeAssertion,
+      fc
+        .constantFrom(TypeError, ReferenceError, RangeError, SyntaxError)
+        .chain((ExpectedCtor) =>
+          fc.tuple(
+            fc.constant({
+              then(
+                _resolve: (value: any) => void,
+                reject: (reason: any) => void,
+              ) {
+                reject(new ExpectedCtor('error'));
+              },
+            }),
+            fc.constantFrom(
+              ...extractPhrases(assertions.promiseRejectWithTypeAssertion),
+            ),
+            fc.constant(ExpectedCtor),
+          ),
+        ),
+    ],
+    [
+      assertions.promiseResolveAssertion,
+      [
+        fc.constant(Promise.resolve('success')),
+        fc.constantFrom(...extractPhrases(assertions.promiseResolveAssertion)),
+      ],
+    ],
+    [
+      assertions.promiseResolveAssertion,
+      [
+        fc.constant(Promise.resolve('success')),
+        fc.constantFrom(...extractPhrases(assertions.promiseResolveAssertion)),
+      ],
+    ],
+    [
+      assertions.promiseResolveWithValueSatisfyingAssertion,
+      fc
+        .string({ maxLength: 20, minLength: 10 })
+        .chain((expected) =>
+          fc.tuple(
+            fc.constant(Promise.resolve(expected)),
+            fc.constantFrom(
+              ...extractPhrases(
+                assertions.promiseResolveWithValueSatisfyingAssertion,
+              ),
+            ),
+            fc.oneof(
+              fc.constant(expected),
+              fc.constant(new RegExp(escapeStringRegexp(expected))),
+            ),
+          ),
+        ),
+    ],
+  ],
+);

--- a/test-data/index.ts
+++ b/test-data/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Test data arbitraries extracted from property tests.
+ *
+ * This module exports fast-check arbitraries for generating valid test data for
+ * all assertions, extracted from the property test configurations. Used by
+ * benchmarks to ensure accurate test data generation.
+ *
+ * @packageDocumentation
+ */
+
+export * from './async-parametric-generators.js';
+export * from './sync-basic-generators.js';
+export * from './sync-collection-generators.js';
+export * from './sync-date-generators.js';
+export * from './sync-esoteric-generators.js';
+export * from './sync-parametric-generators.js';

--- a/test-data/sync-basic-generators.ts
+++ b/test-data/sync-basic-generators.ts
@@ -1,0 +1,346 @@
+import fc from 'fast-check';
+
+import * as assertions from '../src/assertion/impl/sync-basic.js';
+import { type AnyAssertion } from '../src/types.js';
+import { type GeneratorParams } from '../test/property/property-test-config.js';
+import {
+  extractPhrases,
+  filteredAnything,
+  filteredObject,
+} from '../test/property/property-test-util.js';
+
+export const SyncBasicGenerators = new Map<AnyAssertion, GeneratorParams>([
+  [
+    assertions.arrayAssertion,
+    [
+      fc.array(filteredAnything),
+      fc.constantFrom(...extractPhrases(assertions.arrayAssertion)),
+    ],
+  ],
+  [
+    assertions.asyncFunctionAssertion,
+    [
+      fc.oneof(
+        fc.constant(async () => {}),
+        fc.constant(async () => {}),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.asyncFunctionAssertion)),
+    ],
+  ],
+  [
+    assertions.bigintAssertion,
+    [
+      fc.bigInt(),
+      fc.constantFrom(...extractPhrases(assertions.bigintAssertion)),
+    ],
+  ],
+  [
+    assertions.booleanAssertion,
+    [
+      fc.boolean(),
+      fc.constantFrom(...extractPhrases(assertions.booleanAssertion)),
+    ],
+  ],
+  [
+    assertions.classAssertion,
+    [
+      fc.constantFrom(Date, Array, Object, String, Number, Boolean, RegExp),
+      fc.constantFrom(...extractPhrases(assertions.classAssertion)),
+    ],
+  ],
+  [
+    assertions.dateAssertion,
+    [
+      fc.date({ noInvalidDate: true }),
+      fc.constantFrom(...extractPhrases(assertions.dateAssertion)),
+    ],
+  ],
+  [
+    assertions.definedAssertion,
+    [
+      filteredAnything.filter((v) => v !== undefined),
+      fc.constantFrom(...extractPhrases(assertions.definedAssertion)),
+    ],
+  ],
+  [
+    assertions.emptyArrayAssertion,
+    [
+      fc.constant([]),
+      fc.constantFrom(...extractPhrases(assertions.emptyArrayAssertion)),
+    ],
+  ],
+  [
+    assertions.emptyArrayAssertion,
+    [
+      fc.constant([]),
+      fc.constantFrom(...extractPhrases(assertions.emptyArrayAssertion)),
+    ],
+  ],
+  [
+    assertions.emptyObjectAssertion,
+    [
+      fc.constant({}),
+      fc.constantFrom(...extractPhrases(assertions.emptyObjectAssertion)),
+    ],
+  ],
+  [
+    assertions.emptyObjectAssertion,
+    [
+      fc.constant({}),
+      fc.constantFrom(...extractPhrases(assertions.emptyObjectAssertion)),
+    ],
+  ],
+  [
+    assertions.emptyStringAssertion,
+    [
+      fc.constant(''),
+      fc.constantFrom(...extractPhrases(assertions.emptyStringAssertion)),
+    ],
+  ],
+  [
+    assertions.errorAssertion,
+    [
+      fc.oneof(
+        fc.constant(new Error('test')),
+        fc.constant(new TypeError('test')),
+        fc.constant(new ReferenceError('test')),
+        fc.constant(new SyntaxError('test')),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.errorAssertion)),
+    ],
+  ],
+  [
+    assertions.falseAssertion,
+    [
+      fc.constant(false),
+      fc.constantFrom(...extractPhrases(assertions.falseAssertion)),
+    ],
+  ],
+  [
+    assertions.falsyAssertion,
+    [
+      fc.constantFrom(false, 0, '', null, undefined, NaN, 0n),
+      fc.constantFrom(...extractPhrases(assertions.falsyAssertion)),
+    ],
+  ],
+  [
+    assertions.functionAssertion,
+    [
+      fc.oneof(
+        fc.func(filteredAnything),
+        fc.constant(() => {}),
+        fc.constant(() => {}),
+        fc.constant(async () => {}),
+        fc.constant(async () => {}),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.functionAssertion)),
+    ],
+  ],
+  [
+    assertions.infiniteAssertion,
+    [
+      fc.constantFrom(Infinity, -Infinity),
+      fc.constantFrom(...extractPhrases(assertions.infiniteAssertion)),
+    ],
+  ],
+  [
+    assertions.integerAssertion,
+    [
+      fc.integer(),
+      fc.constantFrom(...extractPhrases(assertions.integerAssertion)),
+    ],
+  ],
+  [
+    assertions.nanAssertion,
+    [
+      fc.constant(NaN),
+      fc.constantFrom(...extractPhrases(assertions.nanAssertion)),
+    ],
+  ],
+  [
+    assertions.negativeAssertion,
+    [
+      fc
+        .double({ max: -0.000001, noNaN: true })
+        .filter((v) => Number.isFinite(v) && v < 0),
+      fc.constantFrom(...extractPhrases(assertions.negativeAssertion)),
+    ],
+  ],
+  [
+    assertions.negativeInfinityAssertion,
+    [
+      fc.constant(-Infinity),
+      fc.constantFrom(...extractPhrases(assertions.negativeInfinityAssertion)),
+    ],
+  ],
+  [
+    assertions.negativeIntegerAssertion,
+    [
+      fc.integer({ max: -1 }),
+      fc.constantFrom(...extractPhrases(assertions.negativeIntegerAssertion)),
+    ],
+  ],
+  [
+    assertions.nonEmptyStringAssertion,
+    [
+      fc.string({ minLength: 1 }),
+      fc.constantFrom(...extractPhrases(assertions.nonEmptyStringAssertion)),
+    ],
+  ],
+  [
+    assertions.nullAssertion,
+    [
+      fc.constant(null),
+      fc.constantFrom(...extractPhrases(assertions.nullAssertion)),
+    ],
+  ],
+  [
+    assertions.numberAssertion,
+    [
+      fc.double().filter((v) => Number.isFinite(v)),
+      fc.constantFrom(...extractPhrases(assertions.numberAssertion)),
+    ],
+  ],
+  [
+    assertions.objectAssertion,
+    [
+      fc.oneof(
+        filteredObject,
+        fc.array(filteredAnything),
+        fc.date(),
+        fc.constant(/test/),
+        fc.constant(new Map()),
+        fc.constant(new Set()),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.objectAssertion)),
+    ],
+  ],
+  [
+    assertions.positiveAssertion,
+    [
+      fc
+        .double({ min: 0.000001, noNaN: true })
+        .filter((v) => Number.isFinite(v) && v > 0),
+      fc.constantFrom(...extractPhrases(assertions.positiveAssertion)),
+    ],
+  ],
+  [
+    assertions.positiveInfinityAssertion,
+    [
+      fc.constant(Infinity),
+      fc.constantFrom(...extractPhrases(assertions.positiveInfinityAssertion)),
+    ],
+  ],
+  [
+    assertions.positiveIntegerAssertion,
+    [
+      fc.integer({ min: 1 }),
+      fc.constantFrom(...extractPhrases(assertions.positiveIntegerAssertion)),
+    ],
+  ],
+  [
+    assertions.primitiveAssertion,
+    [
+      fc.oneof(
+        fc.string(),
+        fc.integer(),
+        fc.boolean(),
+        fc.constant(null),
+        fc.constant(undefined),
+        fc.bigInt(),
+        fc.string().map((s) => Symbol(s)),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.primitiveAssertion)),
+    ],
+  ],
+  [
+    assertions.recordAssertion,
+    [
+      filteredObject,
+      fc.constantFrom(...extractPhrases(assertions.recordAssertion)),
+    ],
+  ],
+  [
+    assertions.regexpAssertion,
+    [
+      fc.oneof(
+        fc.constant(/test/),
+        fc.constant(new RegExp('test')),
+        fc
+          .string()
+          .map((s) => new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.regexpAssertion)),
+    ],
+  ],
+  [
+    assertions.setAssertion,
+    [
+      fc.oneof(
+        fc.constant(new Set()),
+        fc.array(filteredAnything).map((arr) => new Set(arr)),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.setAssertion)),
+    ],
+  ],
+  [
+    assertions.stringAssertion,
+    [
+      fc.string(),
+      fc.constantFrom(...extractPhrases(assertions.stringAssertion)),
+    ],
+  ],
+  [
+    assertions.symbolAssertion,
+    [
+      fc.constantFrom(Symbol(), Symbol.for('test'), Symbol.iterator),
+      fc.constantFrom(...extractPhrases(assertions.symbolAssertion)),
+    ],
+  ],
+  [
+    assertions.trueAssertion,
+    [
+      fc.constant(true),
+      fc.constantFrom(...extractPhrases(assertions.trueAssertion)),
+    ],
+  ],
+  [
+    assertions.truthyAssertion,
+    [
+      fc
+        .anything()
+        .filter(
+          (v) =>
+            v !== false &&
+            v !== 0 &&
+            v !== '' &&
+            v !== null &&
+            v !== undefined &&
+            !Number.isNaN(v) &&
+            v !== 0n,
+        ),
+      fc.constantFrom(...extractPhrases(assertions.truthyAssertion)),
+    ],
+  ],
+  [
+    assertions.undefinedAssertion,
+    [
+      fc.constant(undefined),
+      fc.constantFrom(...extractPhrases(assertions.undefinedAssertion)),
+    ],
+  ],
+  [
+    assertions.weakMapAssertion,
+    [
+      fc.constant(new WeakMap()),
+      fc.constantFrom(...extractPhrases(assertions.weakMapAssertion)),
+    ],
+  ],
+  [
+    assertions.weakSetAssertion,
+    [
+      fc.constant(new WeakSet()),
+      fc.constantFrom(...extractPhrases(assertions.weakSetAssertion)),
+    ],
+  ],
+]);

--- a/test-data/sync-collection-generators.ts
+++ b/test-data/sync-collection-generators.ts
@@ -1,0 +1,341 @@
+import fc from 'fast-check';
+
+import * as assertions from '../src/assertion/impl/sync-collection.js';
+import { type AnyAssertion } from '../src/types.js';
+import { type GeneratorParams } from '../test/property/property-test-config.js';
+import {
+  extractPhrases,
+  filteredAnything,
+} from '../test/property/property-test-util.js';
+
+export const SyncCollectionGenerators = new Map<AnyAssertion, GeneratorParams>([
+  [
+    assertions.arrayContainsAssertion,
+    [
+      fc.constant([42, 'test', true]),
+      fc.constantFrom(...extractPhrases(assertions.arrayContainsAssertion)),
+      fc.constantFrom(42, 'test', true),
+    ],
+  ],
+  [
+    assertions.arraySizeAssertion,
+    [
+      fc.constant([1, 2, 3]),
+      fc.constantFrom(...extractPhrases(assertions.arraySizeAssertion)),
+      fc.constant(3),
+    ],
+  ],
+  [
+    assertions.collectionSizeBetweenAssertion,
+    [
+      fc.constantFrom('Map', 'Set').chain((type) => {
+        if (type === 'Map') {
+          return fc.constant(
+            new Map([
+              ['a', 1],
+              ['b', 2],
+              ['c', 3],
+            ]) as any,
+          ); // size 3, within range [2,4]
+        } else {
+          return fc.constant(new Set([1, 2, 3]) as any); // size 3, within range [2,4]
+        }
+      }),
+      fc.constantFrom(
+        ...extractPhrases(assertions.collectionSizeBetweenAssertion),
+      ),
+      fc.constant([2, 4]),
+    ],
+  ],
+  [
+    assertions.collectionSizeGreaterThanAssertion,
+    [
+      fc.constantFrom('Map', 'Set').chain((type) => {
+        if (type === 'Map') {
+          return fc.constant(
+            new Map([
+              ['a', 1],
+              ['b', 2],
+              ['c', 3],
+            ]) as any,
+          ); // size 3
+        } else {
+          return fc.constant(new Set([1, 2, 3]) as any); // size 3
+        }
+      }),
+      fc.constantFrom(
+        ...extractPhrases(assertions.collectionSizeGreaterThanAssertion),
+      ),
+      fc.integer({ max: 2, min: 0 }), // 0 to 2 (less than 3)
+    ],
+  ],
+  [
+    assertions.collectionSizeLessThanAssertion,
+    [
+      fc.oneof(
+        fc
+          .dictionary(fc.string(), filteredAnything, {
+            maxKeys: 2,
+            minKeys: 2,
+          })
+          .map((obj) => new Map(Object.entries(obj))),
+        fc
+          .array(filteredAnything, { maxLength: 2, minLength: 2 })
+          .map((arr) => new Set(arr)),
+      ),
+      fc.constantFrom(
+        ...extractPhrases(assertions.collectionSizeLessThanAssertion),
+      ),
+      fc.integer({ max: 10, min: 3 }),
+    ],
+  ],
+  [
+    assertions.emptyMapAssertion,
+    [
+      fc.constant(new Map()),
+      fc.constantFrom(...extractPhrases(assertions.emptyMapAssertion)),
+    ],
+  ],
+  [
+    assertions.emptySetAssertion,
+    [
+      fc.constant(new Set()),
+      fc.constantFrom(...extractPhrases(assertions.emptySetAssertion)),
+    ],
+  ],
+  [
+    assertions.mapContainsAssertion,
+    [
+      fc.constant(
+        new Map([
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ]),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.mapContainsAssertion)),
+      fc.constantFrom('key1', 'key2'),
+    ],
+  ],
+  [
+    assertions.mapEntryAssertion,
+    [
+      fc.constant(
+        new Map([
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ]),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.mapEntryAssertion)),
+      fc.constantFrom(['key1', 'value1'], ['key2', 'value2']),
+    ],
+  ],
+  [
+    assertions.mapEqualityAssertion,
+    [
+      fc.constant(
+        new Map([
+          ['a', 1],
+          ['b', 2],
+        ]),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.mapEqualityAssertion)),
+      fc.constant(
+        new Map([
+          ['a', 1],
+          ['b', 2],
+        ]),
+      ), // Order doesn't matter
+    ],
+  ],
+  [
+    assertions.mapKeyAssertion,
+    [
+      fc.constant(
+        new Map([
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ]),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.mapKeyAssertion)),
+      fc.constantFrom('key1', 'key2'),
+    ],
+  ],
+  [
+    assertions.mapSizeAssertion,
+    [
+      fc.constant(
+        new Map([
+          ['a', 1],
+          ['b', 2],
+        ]),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.mapSizeAssertion)),
+      fc.constant(2),
+    ],
+  ],
+  [
+    assertions.mapValueAssertion,
+    [
+      fc.constant(
+        new Map([
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ]),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.mapValueAssertion)),
+      fc.constantFrom('value1', 'value2'),
+    ],
+  ],
+  [
+    assertions.nonEmptyArrayAssertion,
+    [
+      fc.array(filteredAnything, { minLength: 1 }),
+      fc.constantFrom(...extractPhrases(assertions.nonEmptyArrayAssertion)),
+    ],
+  ],
+  [
+    assertions.objectExactKeyAssertion,
+    [
+      fc.constant({
+        'key.with.dots': 'direct property',
+        'key[with]brackets': 'another direct property',
+        simple: 'value',
+      }),
+      fc.constantFrom(...extractPhrases(assertions.objectExactKeyAssertion)),
+      fc.constantFrom('key.with.dots', 'key[with]brackets', 'simple'),
+    ],
+  ],
+  [
+    assertions.objectKeyAssertion,
+    [
+      fc.constant({
+        foo: { bar: [{ baz: 'value' }] },
+        items: [{ id: 1, name: 'first' }],
+        'kebab-case': 'works',
+      }),
+      fc.constantFrom(...extractPhrases(assertions.objectKeyAssertion)),
+      fc.constantFrom(
+        'foo.bar',
+        'foo.bar[0].baz',
+        'items[0].id',
+        'items[0].name',
+        'kebab-case',
+      ),
+    ],
+  ],
+  [
+    assertions.objectKeysAssertion,
+    [
+      fc.constant({ a: 1, b: 2, c: 3 }),
+      fc.constantFrom(...extractPhrases(assertions.objectKeysAssertion)),
+      fc.array(fc.constantFrom('a', 'b', 'c'), { minLength: 1 }),
+    ],
+  ],
+  [
+    assertions.objectSizeAssertion,
+    [
+      fc.constant({ a: 1, b: 2, c: 3 }),
+      fc.constantFrom(...extractPhrases(assertions.objectSizeAssertion)),
+      fc.constant(3),
+    ],
+  ],
+  [
+    assertions.setContainsAssertion,
+    [
+      fc.constant(new Set(['val1', 'val2'])),
+      fc.constantFrom(...extractPhrases(assertions.setContainsAssertion)),
+      fc.constantFrom('val1', 'val2'),
+    ],
+  ],
+  [
+    assertions.setDifferenceEqualityAssertion,
+    [
+      fc.constant(new Set([1, 2, 3])),
+      fc.constant('to have difference'),
+      fc.constant(new Set([2, 3, 4])),
+      fc.constant('equal to'),
+      fc.constant(new Set([1])), // Correct difference
+    ],
+  ],
+  [
+    assertions.setDisjointAssertion,
+    [
+      fc.constant(new Set([1, 2])),
+      fc.constantFrom(...extractPhrases(assertions.setDisjointAssertion)),
+      fc.constant(new Set([3, 4])),
+    ],
+  ],
+  [
+    assertions.setEqualityAssertion,
+    [
+      fc.constant(new Set([1, 2, 3])),
+      fc.constantFrom(...extractPhrases(assertions.setEqualityAssertion)),
+      fc.constant(new Set([1, 2, 3])), // Same elements
+    ],
+  ],
+  [
+    assertions.setIntersectionAssertion,
+    [
+      fc.constant(new Set([1, 2, 3])),
+      fc.constantFrom(...extractPhrases(assertions.setIntersectionAssertion)),
+      fc.constant(new Set([2, 3, 4])),
+    ],
+  ],
+  [
+    assertions.setIntersectionEqualityAssertion,
+    [
+      fc.constant(new Set([1, 2, 3])),
+      fc.constant('to have intersection'),
+      fc.constant(new Set([2, 3, 4])),
+      fc.constant('equal to'),
+      fc.constant(new Set([2, 3])), // Correct intersection
+    ],
+  ],
+  [
+    assertions.setSizeAssertion,
+    [
+      fc
+        .array(filteredAnything, { maxLength: 3, minLength: 3 })
+        .map((arr) => new Set(arr))
+        .filter(({ size }) => size === 3), // deduping can shrink it
+      fc.constantFrom(...extractPhrases(assertions.setSizeAssertion)),
+      fc.constant(3),
+    ],
+  ],
+  [
+    assertions.setSubsetAssertion,
+    [
+      fc.constant(new Set([1, 2])),
+      fc.constantFrom(...extractPhrases(assertions.setSubsetAssertion)),
+      fc.constant(new Set([1, 2, 3])),
+    ],
+  ],
+  [
+    assertions.setSupersetAssertion,
+    [
+      fc.constant(new Set([1, 2, 3, 4])),
+      fc.constantFrom(...extractPhrases(assertions.setSupersetAssertion)),
+      fc.constant(new Set([1, 2])),
+    ],
+  ],
+  [
+    assertions.setSymmetricDifferenceEqualityAssertion,
+    [
+      fc.constant(new Set([1, 2, 3])),
+      fc.constant('to have symmetric difference'),
+      fc.constant(new Set([2, 3, 4])),
+      fc.constant('equal to'),
+      fc.constant(new Set([1, 4])), // Correct symmetric difference
+    ],
+  ],
+  [
+    assertions.setUnionEqualityAssertion,
+    [
+      fc.constant(new Set([1, 2])),
+      fc.constant('to have union'),
+      fc.constant(new Set([3, 4])),
+      fc.constant('equal to'),
+      fc.constant(new Set([1, 2, 3, 4])), // Correct union
+    ],
+  ],
+]);

--- a/test-data/sync-date-generators.ts
+++ b/test-data/sync-date-generators.ts
@@ -1,0 +1,259 @@
+import fc from 'fast-check';
+
+import * as assertions from '../src/assertion/impl/sync-date.js';
+import { type AnyAssertion } from '../src/types.js';
+import { type GeneratorParams } from '../test/property/property-test-config.js';
+import { extractPhrases } from '../test/property/property-test-util.js';
+
+/**
+ * Generates past dates
+ */
+export const pastDateGenerator = fc.date({
+  max: new Date(Date.now() - 5000), // At least 5 seconds ago to avoid timing issues
+  noInvalidDate: true,
+});
+
+/**
+ * Generates future dates
+ */
+export const futureDateGenerator = fc.date({
+  min: new Date(Date.now() + 5000), // At least 5 seconds from now to avoid timing issues
+  noInvalidDate: true,
+});
+
+/**
+ * Generates weekend dates (Saturday or Sunday)
+ */
+export const weekendDateGenerator = fc
+  .date({ noInvalidDate: true })
+  .filter((d) => {
+    const day = d.getUTCDay();
+    return day === 0 || day === 6; // Sunday or Saturday
+  });
+
+/**
+ * Generates weekday dates (Monday through Friday)
+ */
+export const weekdayDateGenerator = fc
+  .date({ noInvalidDate: true })
+  .filter((d) => {
+    const day = d.getUTCDay();
+    return day >= 1 && day <= 5; // Monday through Friday
+  });
+
+/**
+ * Generates dates that are known to be today (for testing)
+ */
+const todayDateGenerator = fc.constant(new Date());
+/**
+ * Generates valid date-like values (Date objects, ISO strings, timestamps)
+ */
+export const validDateLikeGenerator = fc
+  .oneof(
+    fc.date({
+      max: new Date('2100-01-01'),
+      min: new Date(0),
+      noInvalidDate: true,
+    }),
+    fc
+      .date({
+        max: new Date('2100-01-01'),
+        min: new Date(0),
+        noInvalidDate: true,
+      })
+      .map((d) => d.toISOString()),
+    fc
+      .date({
+        max: new Date('2100-01-01'),
+        min: new Date(0),
+        noInvalidDate: true,
+      })
+      .map((d) => d.getTime()),
+  )
+  .filter((v) => `${new Date(v)}` !== 'Invalid Date');
+
+export const SyncDateGenerators = new Map<AnyAssertion, GeneratorParams>([
+  [
+    assertions.afterAssertion,
+    fc
+      .tuple(validDateLikeGenerator, validDateLikeGenerator)
+      .filter(([a, b]) => {
+        const dateA = new Date(a);
+        const dateB = new Date(b);
+        return dateA.getTime() > dateB.getTime();
+      })
+      .map(([subject, other]) => [subject, 'to be after', other]),
+  ],
+
+  [
+    assertions.atLeastAgoAssertion,
+    fc
+      .tuple(
+        fc.date({
+          max: new Date(Date.now() - 7200000), // 2 hours ago
+          min: new Date(Date.now() - 86400000), // 1 day ago
+          noInvalidDate: true,
+        }),
+        fc.constant('1 hour'),
+      )
+      .map(([date, duration]) => [date, 'to be at least', duration, 'ago']),
+  ],
+
+  [
+    assertions.atLeastFromNowAssertion,
+    fc
+      .tuple(
+        fc.date({
+          max: new Date(Date.now() + 86400000), // 1 day from now
+          min: new Date(Date.now() + 7200000), // 2 hours from now
+          noInvalidDate: true,
+        }),
+        fc.constant('1 hour'),
+      )
+      .map(([date, duration]) => [
+        date,
+        'to be at least',
+        duration,
+        'from now',
+      ]),
+  ],
+
+  [
+    assertions.beforeAssertion,
+    fc
+      .tuple(validDateLikeGenerator, validDateLikeGenerator)
+      .filter(([a, b]) => {
+        const dateA = new Date(a);
+        const dateB = new Date(b);
+        // Ensure both dates are valid
+        if (isNaN(dateA.getTime()) || isNaN(dateB.getTime())) {
+          return false;
+        }
+        return dateA.getTime() < dateB.getTime();
+      })
+      .map(([subject, other]) => [subject, 'to be before', other]),
+  ],
+
+  [
+    assertions.betweenAssertion,
+    validDateLikeGenerator
+      .chain((subject) =>
+        fc.tuple(
+          fc.constant(subject),
+          fc.date({
+            max: new Date(subject),
+            min: new Date(0),
+            noInvalidDate: true,
+          }),
+          fc.date({
+            max: new Date('2100-01-01'),
+            min: new Date(subject),
+            noInvalidDate: true,
+          }),
+        ),
+      )
+      .map(([subject, start, end]) => [
+        subject,
+        'to be between',
+        start,
+        'and',
+        end,
+      ]),
+  ],
+
+  [
+    assertions.equalWithinAssertion,
+    fc
+      .date({
+        max: new Date('2099-01-01'), // Ensure room for addition
+        min: new Date('2000-01-01'),
+        noInvalidDate: true,
+      })
+      .filter((date) => !Number.isNaN(date.getTime())) // Ensure valid date
+      .map((baseDate) => {
+        const offset = Math.floor(Math.random() * 500); // Within 500ms
+        const closeDate = new Date(baseDate.getTime() + offset);
+        // Ensure the new date is also valid
+        if (isNaN(closeDate.getTime())) {
+          return [baseDate, 'to equal', baseDate, 'within', '1 second'];
+        }
+        return [baseDate, 'to equal', closeDate, 'within', '1 second'];
+      }),
+  ],
+  [
+    assertions.inTheFutureAssertion,
+    [
+      futureDateGenerator,
+      fc.constantFrom(...extractPhrases(assertions.inTheFutureAssertion)),
+    ],
+  ],
+  [
+    assertions.inThePastAssertion,
+    [
+      pastDateGenerator,
+      fc.constantFrom(...extractPhrases(assertions.inThePastAssertion)),
+    ],
+  ],
+  [
+    assertions.sameDateAssertion,
+    fc
+      .date({ noInvalidDate: true })
+      .chain((baseDate) => {
+        const sameDate = new Date(baseDate);
+        return fc.tuple(fc.constant(baseDate), fc.constant(sameDate));
+      })
+      .map(([subject, other]) => [subject, 'to be the same date as', other]),
+  ],
+  [
+    assertions.todayAssertion,
+    [
+      todayDateGenerator,
+      fc.constantFrom(...extractPhrases(assertions.todayAssertion)),
+    ],
+  ],
+  [
+    assertions.validDateAssertion,
+    [
+      validDateLikeGenerator,
+      fc.constantFrom(...extractPhrases(assertions.validDateAssertion)),
+    ],
+  ],
+  [
+    assertions.weekdayAssertion,
+    [
+      weekdayDateGenerator,
+      fc.constantFrom(...extractPhrases(assertions.weekdayAssertion)),
+    ],
+  ],
+  [
+    assertions.weekendAssertion,
+    [
+      weekendDateGenerator,
+      fc.constantFrom(...extractPhrases(assertions.weekendAssertion)),
+    ],
+  ],
+  [
+    assertions.withinAgoAssertion,
+    fc
+      .tuple(
+        fc.date({
+          max: new Date(Date.now() - 10000), // At least 10 seconds ago
+          min: new Date(Date.now() - 1800000), // 30 minutes ago
+          noInvalidDate: true,
+        }),
+        fc.constant('1 hour'),
+      )
+      .map(([date, duration]) => [date, 'to be within', duration, 'ago']),
+  ],
+  [
+    assertions.withinFromNowAssertion,
+    fc
+      .tuple(
+        fc
+          .integer({ max: 1800000, min: 1000 })
+          .map((offsetMs) => new Date(Date.now() + offsetMs)), // 1 second to 30 minutes from now
+        fc.constant('1 hour'),
+      )
+      .map(([date, duration]) => [date, 'to be within', duration, 'from now']),
+  ],
+]);

--- a/test-data/sync-esoteric-generators.ts
+++ b/test-data/sync-esoteric-generators.ts
@@ -1,0 +1,75 @@
+import fc from 'fast-check';
+
+import * as assertions from '../src/assertion/impl/sync-esoteric.js';
+import { type AnyAssertion } from '../src/types.js';
+import { type GeneratorParams } from '../test/property/property-test-config.js';
+import {
+  extractPhrases,
+  filteredObject,
+} from '../test/property/property-test-util.js';
+
+export const SyncEsotericGenerators = new Map<AnyAssertion, GeneratorParams>([
+  [
+    assertions.enumerablePropertyAssertion,
+    [
+      fc.constant('a'),
+      fc.constantFrom(
+        ...extractPhrases(assertions.enumerablePropertyAssertion),
+      ),
+      fc.constant({}).map((obj) => {
+        Object.defineProperty(obj, 'a', {
+          enumerable: true,
+          value: 42,
+        });
+        return obj;
+      }),
+    ],
+  ],
+  [
+    assertions.enumerablePropertyAssertion2,
+    [
+      filteredObject.map((obj) => {
+        Object.defineProperty(obj, 'a', {
+          enumerable: true,
+          value: 42,
+        });
+        return obj;
+      }),
+      fc.constantFrom(
+        ...extractPhrases(assertions.enumerablePropertyAssertion2),
+      ),
+      fc.constant('a'),
+    ],
+  ],
+  [
+    assertions.extensibleAssertion,
+    [
+      filteredObject,
+      fc.constantFrom(...extractPhrases(assertions.extensibleAssertion)),
+    ],
+  ],
+  [
+    assertions.frozenAssertion,
+    [
+      filteredObject.map(Object.freeze),
+      fc.constantFrom(...extractPhrases(assertions.frozenAssertion)),
+    ],
+  ],
+  [
+    assertions.nullPrototypeAssertion,
+    [
+      fc.constant(Object.create(null)),
+      fc.constantFrom(...extractPhrases(assertions.nullPrototypeAssertion)),
+    ],
+  ],
+  [
+    assertions.sealedAssertion,
+    [
+      filteredObject.map((obj) => {
+        Object.seal(obj);
+        return obj;
+      }),
+      fc.constantFrom(...extractPhrases(assertions.sealedAssertion)),
+    ],
+  ],
+]);

--- a/test-data/sync-parametric-generators.ts
+++ b/test-data/sync-parametric-generators.ts
@@ -1,0 +1,488 @@
+import escapeStringRegexp from 'escape-string-regexp';
+import fc from 'fast-check';
+
+import * as assertions from '../src/assertion/impl/sync-parametric.js';
+import { type AnyAssertion } from '../src/types.js';
+import { type GeneratorParams } from '../test/property/property-test-config.js';
+import {
+  extractPhrases,
+  filteredAnything,
+  filteredObject,
+  objectFilter,
+  safeRegexStringFilter,
+} from '../test/property/property-test-util.js';
+
+export const SyncParametricGenerators = new Map<AnyAssertion, GeneratorParams>([
+  [
+    assertions.arrayDeepEqualAssertion,
+    fc
+      .array(filteredAnything, { minLength: 1, size: 'small' })
+      .filter(objectFilter)
+      .chain((expected) =>
+        fc.tuple(
+          fc.constant(structuredClone(expected)),
+          fc.constantFrom(
+            ...extractPhrases(assertions.arrayDeepEqualAssertion),
+          ),
+          fc.constant(expected),
+        ),
+      ),
+  ],
+  [
+    assertions.arraySatisfiesAssertion,
+    fc
+      .array(filteredAnything, { minLength: 1, size: 'small' })
+      .filter(objectFilter)
+      .chain((expected) =>
+        fc.tuple(
+          fc.constant(structuredClone(expected)),
+          fc.constantFrom(
+            ...extractPhrases(assertions.arraySatisfiesAssertion),
+          ),
+          fc.constant(expected),
+        ),
+      ),
+  ],
+  [
+    assertions.errorMessageAssertion,
+    fc
+      .string()
+      .chain((expectedMessage) =>
+        fc.tuple(
+          fc.constant(new Error(expectedMessage)),
+          fc.constantFrom(...extractPhrases(assertions.errorMessageAssertion)),
+          fc.constant(expectedMessage),
+        ),
+      ),
+  ],
+  [
+    assertions.errorMessageMatchingAssertion,
+    fc
+      .string({ maxLength: 5, minLength: 1 })
+      .map(safeRegexStringFilter)
+      .filter((message) => !!message.length)
+      .chain((message) =>
+        fc.tuple(
+          fc.constant(new Error(message)),
+          fc.constantFrom(
+            ...extractPhrases(assertions.errorMessageMatchingAssertion),
+          ),
+          fc.constant(new RegExp(escapeStringRegexp(message))),
+        ),
+      ),
+  ],
+  [
+    assertions.functionArityAssertion,
+    fc.integer({ max: 5, min: 0 }).chain((arity) =>
+      fc.tuple(
+        fc.func(filteredAnything).map(() => {
+          switch (arity) {
+            case 0:
+              return () => 0;
+            case 1:
+              return (a: unknown) => a;
+            case 2:
+              return (a: unknown, b: unknown) => String(a) + String(b);
+            case 3:
+              return (a: unknown, b: unknown, c: unknown) =>
+                String(a) + String(b) + String(c);
+            case 4:
+              return (a: unknown, b: unknown, c: unknown, d: unknown) =>
+                String(a) + String(b) + String(c) + String(d);
+            default:
+              return (
+                a: unknown,
+                b: unknown,
+                c: unknown,
+                d: unknown,
+                e: unknown,
+              ) => String(a) + String(b) + String(c) + String(d) + String(e);
+          }
+        }),
+        fc.constantFrom(...extractPhrases(assertions.functionArityAssertion)),
+        fc.constant(arity),
+      ),
+    ),
+  ],
+  [
+    assertions.functionThrowsAssertion,
+    [
+      fc.constant(() => {
+        throw new Error('test error');
+      }),
+      fc.constantFrom(...extractPhrases(assertions.functionThrowsAssertion)),
+    ],
+  ],
+  [
+    assertions.functionThrowsSatisfyingAssertion,
+    [
+      fc.constant(() => {
+        throw new Error('hello world');
+      }),
+      fc.constantFrom(
+        ...extractPhrases(assertions.functionThrowsSatisfyingAssertion),
+      ),
+      fc.constant(/hello/),
+    ],
+  ],
+  [
+    assertions.functionThrowsTypeAssertion,
+    [
+      fc.constant(() => {
+        throw new Error('test');
+      }),
+      fc.constantFrom(
+        ...extractPhrases(assertions.functionThrowsTypeAssertion),
+      ),
+      fc.constant(Error),
+    ],
+  ],
+  [
+    assertions.functionThrowsTypeSatisfyingAssertion,
+    [
+      fc.constant(() => {
+        throw new Error('test message');
+      }),
+      fc.constantFrom('to throw a', 'to throw an'),
+      fc.constant(Error), // Expect Error and will get Error
+      fc.constant('satisfying'),
+      fc.constantFrom(
+        { message: 'test message' },
+        'test message',
+        /test message/,
+      ),
+    ],
+  ],
+  [
+    assertions.instanceOfAssertion,
+    [
+      fc.constant(new Error('test')),
+      fc.constantFrom(...extractPhrases(assertions.instanceOfAssertion)),
+      fc.constant(Error),
+    ],
+  ],
+  [
+    assertions.numberCloseToAssertion,
+    fc.integer({ max: 100, min: -100 }).chain((target) =>
+      fc.integer({ max: 10, min: 1 }).chain((tolerance) =>
+        fc.tuple(
+          fc.integer({
+            max: target + tolerance,
+            min: target - tolerance,
+          }),
+          fc.constantFrom(...extractPhrases(assertions.numberCloseToAssertion)),
+          fc.constant(target),
+          fc.constant(tolerance),
+        ),
+      ),
+    ),
+  ],
+  [
+    assertions.numberGreaterThanAssertion,
+    fc
+      .integer({ max: 5, min: 1 })
+      .chain((threshold) =>
+        fc.tuple(
+          fc.integer({ max: 10, min: 6 }),
+          fc.constantFrom(
+            ...extractPhrases(assertions.numberGreaterThanAssertion),
+          ),
+          fc.constant(threshold),
+        ),
+      ),
+  ],
+  [
+    assertions.numberGreaterThanOrEqualAssertion,
+    fc
+      .integer({ max: 50, min: -50 })
+      .chain((threshold) =>
+        fc.tuple(
+          fc.integer({ min: threshold }),
+          fc.constantFrom(
+            ...extractPhrases(assertions.numberGreaterThanOrEqualAssertion),
+          ),
+          fc.constant(threshold),
+        ),
+      ),
+  ],
+  [
+    assertions.numberLessThanAssertion,
+    fc
+      .integer({ max: 50, min: -50 })
+      .chain((threshold) =>
+        fc.tuple(
+          fc.integer({ max: threshold - 1 }),
+          fc.constantFrom(
+            ...extractPhrases(assertions.numberLessThanAssertion),
+          ),
+          fc.constant(threshold),
+        ),
+      ),
+  ],
+  [
+    assertions.numberLessThanOrEqualAssertion,
+    fc
+      .integer({ max: 50, min: -50 })
+      .chain((threshold) =>
+        fc.tuple(
+          fc.integer({ max: threshold }),
+          fc.constantFrom(
+            ...extractPhrases(assertions.numberLessThanOrEqualAssertion),
+          ),
+          fc.constant(threshold),
+        ),
+      ),
+  ],
+  [
+    assertions.numberWithinRangeAssertion,
+    fc.integer({ max: 50, min: 0 }).chain((min) =>
+      fc.integer({ max: 100, min: min + 5 }).chain((max) =>
+        fc.tuple(
+          fc.integer({ max, min }), // Within range
+          fc.constantFrom(
+            ...extractPhrases(assertions.numberWithinRangeAssertion),
+          ),
+          fc.constant(min),
+          fc.constant(max),
+        ),
+      ),
+    ),
+  ],
+  [
+    assertions.objectDeepEqualAssertion,
+    fc
+      .object()
+      .filter(objectFilter)
+      .chain((expected) =>
+        fc.tuple(
+          fc.constant(structuredClone(expected)),
+          fc.constantFrom(
+            ...extractPhrases(assertions.objectDeepEqualAssertion),
+          ),
+          fc.constant(expected),
+        ),
+      ),
+  ],
+  [
+    assertions.objectSatisfiesAssertion,
+    fc
+      .object({ depthSize: 'small' })
+      .filter(objectFilter)
+      .chain((expected) =>
+        fc.tuple(
+          fc.constant(structuredClone(expected)),
+          fc.constantFrom(
+            ...extractPhrases(assertions.objectSatisfiesAssertion),
+          ),
+          fc.constant(expected),
+        ),
+      ),
+  ],
+  [
+    assertions.oneOfAssertion,
+    [
+      fc.oneof(
+        fc.constant('test'),
+        fc.constant('other1'),
+        fc.constant('other2'),
+      ),
+      fc.constantFrom(...extractPhrases(assertions.oneOfAssertion)),
+      fc.constant(['test', 'other1', 'other2']),
+    ],
+  ],
+  [
+    assertions.strictEqualityAssertion,
+    fc
+      .anything()
+      .filter((v) => !Number.isNaN(v))
+      .chain((value) =>
+        fc.tuple(
+          fc.constant(value),
+          fc.constantFrom(
+            ...extractPhrases(assertions.strictEqualityAssertion),
+          ),
+          fc.constant(value),
+        ),
+      ),
+  ],
+  [
+    assertions.stringBeginsWithAssertion,
+    fc
+      .string({ minLength: 2 })
+      .chain((str) =>
+        fc
+          .integer({ max: str.length, min: 1 })
+          .chain((prefixLength) =>
+            fc.tuple(
+              fc.constant(str),
+              fc.constantFrom(
+                ...extractPhrases(assertions.stringBeginsWithAssertion),
+              ),
+              fc.constant(str.substring(0, prefixLength)),
+            ),
+          ),
+      ),
+  ],
+  [
+    assertions.stringEndsWithAssertion,
+    fc
+      .string({ minLength: 2 })
+      .chain((str) =>
+        fc
+          .integer({ max: str.length, min: 1 })
+          .chain((suffixLength) =>
+            fc.tuple(
+              fc.constant(str),
+              fc.constantFrom(
+                ...extractPhrases(assertions.stringEndsWithAssertion),
+              ),
+              fc.constant(str.substring(str.length - suffixLength)),
+            ),
+          ),
+      ),
+  ],
+  [
+    assertions.stringGreaterThanAssertion,
+    fc.string({ maxLength: 5, minLength: 1 }).chain((threshold) =>
+      fc.tuple(
+        fc.constant(threshold + 'a'), // Simple: append 'a' to make it greater
+        fc.constantFrom(
+          ...extractPhrases(assertions.stringGreaterThanAssertion),
+        ),
+        fc.constant(threshold),
+      ),
+    ),
+  ],
+
+  [
+    assertions.stringGreaterThanOrEqualAssertion,
+
+    fc.string({ maxLength: 5, minLength: 1 }).chain((threshold) =>
+      fc.tuple(
+        fc.oneof(
+          fc.constant(threshold), // Equal case
+          fc.constant(threshold + 'a'), // Greater case: append 'a'
+        ),
+        fc.constantFrom(
+          ...extractPhrases(assertions.stringGreaterThanOrEqualAssertion),
+        ),
+        fc.constant(threshold),
+      ),
+    ),
+  ],
+
+  [
+    assertions.stringIncludesAssertion,
+    fc
+      .string({ minLength: 3 })
+      .chain((str) =>
+        fc
+          .integer({ max: str.length - 1, min: 1 })
+          .chain((startIndex) =>
+            fc
+              .integer({ max: str.length - startIndex, min: 1 })
+              .chain((length) =>
+                fc.tuple(
+                  fc.constant(str),
+                  fc.constantFrom(
+                    ...extractPhrases(assertions.stringIncludesAssertion),
+                  ),
+                  fc.constant(str.substring(startIndex, startIndex + length)),
+                ),
+              ),
+          ),
+      ),
+  ],
+
+  [
+    assertions.stringLessThanAssertion,
+    fc.string({ maxLength: 5, minLength: 1 }).chain((threshold) =>
+      fc.tuple(
+        // Generate string guaranteed to be less than threshold
+        fc.constant(
+          threshold.length > 0 && threshold.charCodeAt(0) > 32
+            ? ' '.repeat(threshold.length)
+            : '',
+        ),
+        fc.constantFrom(...extractPhrases(assertions.stringLessThanAssertion)),
+        fc.constant(threshold),
+      ),
+    ),
+  ],
+
+  [
+    assertions.stringLessThanOrEqualAssertion,
+    fc.string({ maxLength: 5, minLength: 1 }).chain((threshold) =>
+      fc.tuple(
+        fc.oneof(
+          fc.constant(threshold), // Equal case
+          // Less case: if threshold starts with a character > space, replace with space
+          // Otherwise use empty string (which is always < any non-empty string)
+          fc.constant(
+            threshold.length > 0 && threshold.charCodeAt(0) > 32
+              ? ' '.repeat(threshold.length)
+              : '',
+          ),
+        ),
+        fc.constantFrom(
+          ...extractPhrases(assertions.stringLessThanOrEqualAssertion),
+        ),
+        fc.constant(threshold),
+      ),
+    ),
+  ],
+
+  [
+    assertions.stringMatchesAssertion,
+    fc
+      .string({ maxLength: 5, minLength: 1 })
+      .map(safeRegexStringFilter)
+      .filter((str) => !!str.length)
+      .chain((str) =>
+        fc.tuple(
+          fc.constant(str),
+          fc.constantFrom(...extractPhrases(assertions.stringMatchesAssertion)),
+          fc.constant(new RegExp(escapeStringRegexp(str))),
+        ),
+      ),
+  ],
+
+  [
+    assertions.typeOfAssertion,
+    fc
+      .oneof(
+        // Generate value-type pairs where value matches the type
+        fc.constant([fc.string(), 'string']),
+        fc.constant([
+          fc.float({ noDefaultInfinity: true, noNaN: true }),
+          'number',
+        ]),
+        fc.constant([fc.boolean(), 'boolean']),
+        fc.constant([fc.constant(undefined), 'undefined']),
+        fc.constant([fc.constant(null), 'null']),
+        fc.constant([fc.constant(BigInt(1)), 'bigint']),
+        fc.constant([fc.constant(Symbol('test')), 'symbol']),
+        fc.constant([filteredObject, 'object']),
+        fc.constant([fc.func(filteredAnything), 'function']),
+        fc.constant([fc.array(filteredAnything), 'array']),
+        fc.constant([fc.constant(new Date()), 'date']),
+        fc.constant([fc.constant(new Map()), 'map']),
+        fc.constant([fc.constant(new Set()), 'set']),
+        fc.constant([fc.constant(new WeakMap()), 'weakmap']),
+        fc.constant([fc.constant(new WeakSet()), 'weakset']),
+        fc.constant([fc.constant(/test/), 'regexp']),
+        fc.constant([fc.constant(Promise.resolve()), 'promise']),
+        fc.constant([fc.constant(new Error()), 'error']),
+        fc.constant([fc.constant(new WeakRef({})), 'weakref']),
+      )
+      .chain(([valueGen, typeString]) =>
+        valueGen.chain((value) =>
+          fc.tuple(
+            fc.constant(value),
+            fc.constantFrom(...extractPhrases(assertions.typeOfAssertion)),
+            fc.constant(typeString), // Only use lowercase
+          ),
+        ),
+      ),
+  ],
+] as const);

--- a/test/property/async-parametric.test.ts
+++ b/test/property/async-parametric.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 import * as assertions from '../../src/assertion/impl/async-parametric.js';
 import { AsyncParametricAssertions } from '../../src/assertion/index.js';
 import { type AnyAssertion } from '../../src/types.js';
+import { AsyncParametricGenerators } from '../../test-data/async-parametric-generators.js';
 import { expect } from '../custom-assertions.js';
 import {
   type PropertyTestConfig,
@@ -61,21 +62,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: fc
-          .string({ maxLength: 9, minLength: 7 })
-          .map(safeRegexStringFilter)
-          .filter((message) => !!message.length)
-          .chain((str) =>
-            fc.tuple(
-              fc.constant(async () => str),
-              fc.constantFrom(
-                ...extractPhrases(
-                  assertions.functionFulfillWithValueSatisfyingAssertion,
-                ),
-              ),
-              fc.constant(str),
-            ),
-          ),
+        generators: AsyncParametricGenerators.get(
+          assertions.functionFulfillWithValueSatisfyingAssertion,
+        )!,
       },
     },
   ],
@@ -97,16 +86,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: fc.string().chain((expected) =>
-          fc.tuple(
-            fc.constant(async () => {
-              throw new Error(expected);
-            }),
-            fc.constantFrom(
-              ...extractPhrases(assertions.functionRejectAssertion),
-            ),
-          ),
-        ),
+        generators: AsyncParametricGenerators.get(
+          assertions.functionRejectAssertion,
+        )!,
       },
     },
   ],
@@ -151,30 +133,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: fc
-          .string({ maxLength: 5, minLength: 1 })
-          .map(safeRegexStringFilter)
-          .filter((actual) => !!actual.length)
-          .chain((expected) =>
-            fc.tuple(
-              fc.constant(async () => {
-                throw new Error(expected);
-              }),
-              fc.constantFrom(
-                ...extractPhrases(
-                  assertions.functionRejectWithErrorSatisfyingAssertion,
-                ),
-              ),
-              fc.oneof(
-                fc.constant(expected),
-                fc.constant(new RegExp(escapeStringRegexp(expected))),
-                fc.constant({ message: expected }),
-                fc.constant({
-                  message: new RegExp(escapeStringRegexp(expected)),
-                }),
-              ),
-            ),
-          ),
+        generators: AsyncParametricGenerators.get(
+          assertions.functionRejectWithErrorSatisfyingAssertion,
+        )!,
       },
     },
   ],
@@ -207,19 +168,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: fc
-          .constantFrom(TypeError, ReferenceError, RangeError, SyntaxError)
-          .chain((ErrorCtor) =>
-            fc.tuple(
-              fc.constant(async () => {
-                throw new ErrorCtor('error');
-              }),
-              fc.constantFrom(
-                ...extractPhrases(assertions.functionRejectWithTypeAssertion),
-              ),
-              fc.constant(ErrorCtor),
-            ),
-          ),
+        generators: AsyncParametricGenerators.get(
+          assertions.functionRejectWithTypeAssertion,
+        )!,
       },
     },
   ],
@@ -240,12 +191,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: [
-          fc.constant(async () => 'success'),
-          fc.constantFrom(
-            ...extractPhrases(assertions.functionResolveAssertion),
-          ),
-        ],
+        generators: AsyncParametricGenerators.get(
+          assertions.functionResolveAssertion,
+        )!,
       },
     },
   ],
@@ -262,17 +210,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: [
-          fc.constant({
-            then(
-              _resolve: (value: any) => void,
-              reject: (reason: any) => void,
-            ) {
-              reject(new Error('rejection'));
-            },
-          }),
-          fc.constantFrom(...extractPhrases(assertions.promiseRejectAssertion)),
-        ],
+        generators: AsyncParametricGenerators.get(
+          assertions.promiseRejectAssertion,
+        )!,
       },
     },
   ],
@@ -308,24 +248,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: fc.string().chain((message) =>
-          fc.tuple(
-            fc.constant({
-              then(
-                _resolve: (value: any) => void,
-                reject: (reason: any) => void,
-              ) {
-                reject(new Error(message));
-              },
-            }),
-            fc.constantFrom(
-              ...extractPhrases(
-                assertions.promiseRejectWithErrorSatisfyingAssertion,
-              ),
-            ),
-            fc.constant(message),
-          ),
-        ),
+        generators: AsyncParametricGenerators.get(
+          assertions.promiseRejectWithErrorSatisfyingAssertion,
+        )!,
       },
     },
   ],
@@ -363,24 +288,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: fc
-          .constantFrom(TypeError, ReferenceError, RangeError, SyntaxError)
-          .chain((ExpectedCtor) =>
-            fc.tuple(
-              fc.constant({
-                then(
-                  _resolve: (value: any) => void,
-                  reject: (reason: any) => void,
-                ) {
-                  reject(new ExpectedCtor('error'));
-                },
-              }),
-              fc.constantFrom(
-                ...extractPhrases(assertions.promiseRejectWithTypeAssertion),
-              ),
-              fc.constant(ExpectedCtor),
-            ),
-          ),
+        generators: AsyncParametricGenerators.get(
+          assertions.promiseRejectWithTypeAssertion,
+        )!,
       },
     },
   ],
@@ -406,12 +316,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: [
-          fc.constant(Promise.resolve('success')),
-          fc.constantFrom(
-            ...extractPhrases(assertions.promiseResolveAssertion),
-          ),
-        ],
+        generators: AsyncParametricGenerators.get(
+          assertions.promiseResolveAssertion,
+        )!,
       },
     },
   ],
@@ -458,22 +365,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         async: true,
-        generators: fc
-          .string({ maxLength: 20, minLength: 10 })
-          .chain((expected) =>
-            fc.tuple(
-              fc.constant(Promise.resolve(expected)),
-              fc.constantFrom(
-                ...extractPhrases(
-                  assertions.promiseResolveWithValueSatisfyingAssertion,
-                ),
-              ),
-              fc.oneof(
-                fc.constant(expected),
-                fc.constant(new RegExp(escapeStringRegexp(expected))),
-              ),
-            ),
-          ),
+        generators: AsyncParametricGenerators.get(
+          assertions.promiseResolveWithValueSatisfyingAssertion,
+        )!,
       },
     },
   ],

--- a/test/property/property-test-config.ts
+++ b/test/property/property-test-config.ts
@@ -14,17 +14,25 @@ import type { Parameters } from 'fast-check';
 
 import { z } from 'zod/v4';
 
+export type GeneratorParams =
+  | fc.Arbitrary<readonly [subject: unknown, phrase: string, ...unknown[]]>
+  | readonly [
+      subject: fc.Arbitrary<any>,
+      phrase: fc.Arbitrary<string>,
+      ...fc.Arbitrary<any>[],
+    ];
+
 export type InferPropertyTestConfigVariantAsyncProperty<T> =
   T extends PropertyTestConfigVariantAsyncProperty<infer U>
     ? PropertyTestConfigVariantAsyncProperty<U>
     : never;
-
 export type InferPropertyTestConfigVariantModel<
   T extends PropertyTestConfigVariant,
 > =
   T extends PropertyTestConfigVariantModel<infer M, infer R>
     ? PropertyTestConfigVariantModel<M, R>
     : never;
+
 export type InferPropertyTestConfigVariantProperty<T> =
   T extends PropertyTestConfigVariantProperty<infer U>
     ? PropertyTestConfigVariantProperty<U>
@@ -118,13 +126,7 @@ export interface PropertyTestConfigVariantProperty<T = any>
 
 export interface PropertyTestConfigVariantSyncGenerators
   extends PropertyTestConfigParameters {
-  generators:
-    | fc.Arbitrary<readonly [subject: unknown, phrase: string, ...unknown[]]>
-    | readonly [
-        subject: fc.Arbitrary<any>,
-        phrase: fc.Arbitrary<string>,
-        ...fc.Arbitrary<any>[],
-      ];
+  generators: GeneratorParams;
 }
 
 // Shared schema for PropertyTestConfigParameters

--- a/test/property/sync-basic.test.ts
+++ b/test/property/sync-basic.test.ts
@@ -5,6 +5,7 @@ import type { AnyAssertion } from '../../src/types.js';
 
 import * as assertions from '../../src/assertion/impl/sync-basic.js';
 import { SyncBasicAssertions } from '../../src/assertion/index.js';
+import { SyncBasicGenerators } from '../../test-data/sync-basic-generators.js';
 import { expect } from '../custom-assertions.js';
 import {
   type PropertyTestConfig,
@@ -13,7 +14,6 @@ import {
 import {
   extractPhrases,
   filteredAnything,
-  filteredObject,
   getVariants,
   runVariant,
 } from './property-test-util.js';
@@ -41,10 +41,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.array(filteredAnything),
-          fc.constantFrom(...extractPhrases(assertions.arrayAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.arrayAssertion)!,
       },
     },
   ],
@@ -65,13 +62,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.oneof(
-            fc.constant(async () => {}),
-            fc.constant(async () => {}),
-          ),
-          fc.constantFrom(...extractPhrases(assertions.asyncFunctionAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.asyncFunctionAssertion)!,
       },
     },
   ],
@@ -86,10 +77,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.bigInt(),
-          fc.constantFrom(...extractPhrases(assertions.bigintAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.bigintAssertion)!,
       },
     },
   ],
@@ -104,10 +92,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.boolean(),
-          fc.constantFrom(...extractPhrases(assertions.booleanAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.booleanAssertion)!,
       },
     },
   ],
@@ -129,10 +114,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constantFrom(Date, Array, Object, String, Number, Boolean, RegExp),
-          fc.constantFrom(...extractPhrases(assertions.classAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.classAssertion)!,
       },
     },
   ],
@@ -147,10 +129,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.date({ noInvalidDate: true }),
-          fc.constantFrom(...extractPhrases(assertions.dateAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.dateAssertion)!,
       },
     },
   ],
@@ -166,10 +145,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
       },
       valid: {
         examples: [[null, 'to be defined']],
-        generators: [
-          filteredAnything.filter((v) => v !== undefined),
-          fc.constantFrom(...extractPhrases(assertions.definedAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.definedAssertion)!,
       },
     },
   ],
@@ -184,28 +160,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant([]),
-          fc.constantFrom(...extractPhrases(assertions.emptyArrayAssertion)),
-        ],
-      },
-    },
-  ],
-
-  [
-    assertions.emptyArrayAssertion,
-    {
-      invalid: {
-        generators: [
-          fc.array(filteredAnything, { minLength: 1 }),
-          fc.constantFrom(...extractPhrases(assertions.emptyArrayAssertion)),
-        ],
-      },
-      valid: {
-        generators: [
-          fc.constant([]),
-          fc.constantFrom(...extractPhrases(assertions.emptyArrayAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.emptyArrayAssertion)!,
       },
     },
   ],
@@ -222,28 +177,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant({}),
-          fc.constantFrom(...extractPhrases(assertions.emptyObjectAssertion)),
-        ],
-      },
-    },
-  ],
-
-  [
-    assertions.emptyObjectAssertion,
-    {
-      invalid: {
-        generators: [
-          filteredObject.filter((obj) => Object.keys(obj).length > 0),
-          fc.constantFrom(...extractPhrases(assertions.emptyObjectAssertion)),
-        ],
-      },
-      valid: {
-        generators: [
-          fc.constant({}),
-          fc.constantFrom(...extractPhrases(assertions.emptyObjectAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.emptyObjectAssertion)!,
       },
     },
   ],
@@ -258,10 +192,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(''),
-          fc.constantFrom(...extractPhrases(assertions.emptyStringAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.emptyStringAssertion)!,
       },
     },
   ],
@@ -276,15 +207,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.oneof(
-            fc.constant(new Error('test')),
-            fc.constant(new TypeError('test')),
-            fc.constant(new ReferenceError('test')),
-            fc.constant(new SyntaxError('test')),
-          ),
-          fc.constantFrom(...extractPhrases(assertions.errorAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.errorAssertion)!,
       },
     },
   ],
@@ -299,10 +222,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(false),
-          fc.constantFrom(...extractPhrases(assertions.falseAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.falseAssertion)!,
       },
     },
   ],
@@ -328,10 +248,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constantFrom(false, 0, '', null, undefined, NaN, 0n),
-          fc.constantFrom(...extractPhrases(assertions.falsyAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.falsyAssertion)!,
       },
     },
   ],
@@ -346,16 +263,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.oneof(
-            fc.func(filteredAnything),
-            fc.constant(() => {}),
-            fc.constant(() => {}),
-            fc.constant(async () => {}),
-            fc.constant(async () => {}),
-          ),
-          fc.constantFrom(...extractPhrases(assertions.functionAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.functionAssertion)!,
       },
     },
   ],
@@ -375,10 +283,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constantFrom(Infinity, -Infinity),
-          fc.constantFrom(...extractPhrases(assertions.infiniteAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.infiniteAssertion)!,
       },
     },
   ],
@@ -400,10 +305,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.integer(),
-          fc.constantFrom(...extractPhrases(assertions.integerAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.integerAssertion)!,
       },
     },
   ],
@@ -418,10 +320,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(NaN),
-          fc.constantFrom(...extractPhrases(assertions.nanAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.nanAssertion)!,
       },
     },
   ],
@@ -440,12 +339,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc
-            .double({ max: -0.000001, noNaN: true })
-            .filter((v) => Number.isFinite(v) && v < 0),
-          fc.constantFrom(...extractPhrases(assertions.negativeAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.negativeAssertion)!,
       },
     },
   ],
@@ -462,12 +356,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(-Infinity),
-          fc.constantFrom(
-            ...extractPhrases(assertions.negativeInfinityAssertion),
-          ),
-        ],
+        generators: SyncBasicGenerators.get(
+          assertions.negativeInfinityAssertion,
+        )!,
       },
     },
   ],
@@ -492,12 +383,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.integer({ max: -1 }),
-          fc.constantFrom(
-            ...extractPhrases(assertions.negativeIntegerAssertion),
-          ),
-        ],
+        generators: SyncBasicGenerators.get(
+          assertions.negativeIntegerAssertion,
+        )!,
       },
     },
   ],
@@ -514,12 +402,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.string({ minLength: 1 }),
-          fc.constantFrom(
-            ...extractPhrases(assertions.nonEmptyStringAssertion),
-          ),
-        ],
+        generators: SyncBasicGenerators.get(
+          assertions.nonEmptyStringAssertion,
+        )!,
       },
     },
   ],
@@ -534,10 +419,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(null),
-          fc.constantFrom(...extractPhrases(assertions.nullAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.nullAssertion)!,
       },
     },
   ],
@@ -554,10 +436,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.double().filter((v) => Number.isFinite(v)),
-          fc.constantFrom(...extractPhrases(assertions.numberAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.numberAssertion)!,
       },
     },
   ],
@@ -572,17 +451,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.oneof(
-            filteredObject,
-            fc.array(filteredAnything),
-            fc.date(),
-            fc.constant(/test/),
-            fc.constant(new Map()),
-            fc.constant(new Set()),
-          ),
-          fc.constantFrom(...extractPhrases(assertions.objectAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.objectAssertion)!,
       },
     },
   ],
@@ -601,12 +470,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc
-            .double({ min: 0.000001, noNaN: true })
-            .filter((v) => Number.isFinite(v) && v > 0),
-          fc.constantFrom(...extractPhrases(assertions.positiveAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.positiveAssertion)!,
       },
     },
   ],
@@ -623,12 +487,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(Infinity),
-          fc.constantFrom(
-            ...extractPhrases(assertions.positiveInfinityAssertion),
-          ),
-        ],
+        generators: SyncBasicGenerators.get(
+          assertions.positiveInfinityAssertion,
+        )!,
       },
     },
   ],
@@ -653,12 +514,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.integer({ min: 1 }),
-          fc.constantFrom(
-            ...extractPhrases(assertions.positiveIntegerAssertion),
-          ),
-        ],
+        generators: SyncBasicGenerators.get(
+          assertions.positiveIntegerAssertion,
+        )!,
       },
     },
   ],
@@ -678,18 +536,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.oneof(
-            fc.string(),
-            fc.integer(),
-            fc.boolean(),
-            fc.constant(null),
-            fc.constant(undefined),
-            fc.bigInt(),
-            fc.string().map((s) => Symbol(s)),
-          ),
-          fc.constantFrom(...extractPhrases(assertions.primitiveAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.primitiveAssertion)!,
       },
     },
   ],
@@ -715,10 +562,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          filteredObject,
-          fc.constantFrom(...extractPhrases(assertions.recordAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.recordAssertion)!,
       },
     },
   ],
@@ -733,16 +577,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.oneof(
-            fc.constant(/test/),
-            fc.constant(new RegExp('test')),
-            fc
-              .string()
-              .map((s) => new RegExp(s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))),
-          ),
-          fc.constantFrom(...extractPhrases(assertions.regexpAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.regexpAssertion)!,
       },
     },
   ],
@@ -757,13 +592,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.oneof(
-            fc.constant(new Set()),
-            fc.array(filteredAnything).map((arr) => new Set(arr)),
-          ),
-          fc.constantFrom(...extractPhrases(assertions.setAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.setAssertion)!,
       },
     },
   ],
@@ -778,10 +607,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.string(),
-          fc.constantFrom(...extractPhrases(assertions.stringAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.stringAssertion)!,
       },
     },
   ],
@@ -796,10 +622,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constantFrom(Symbol(), Symbol.for('test'), Symbol.iterator),
-          fc.constantFrom(...extractPhrases(assertions.symbolAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.symbolAssertion)!,
       },
     },
   ],
@@ -814,10 +637,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(true),
-          fc.constantFrom(...extractPhrases(assertions.trueAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.trueAssertion)!,
       },
     },
   ],
@@ -832,21 +652,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc
-            .anything()
-            .filter(
-              (v) =>
-                v !== false &&
-                v !== 0 &&
-                v !== '' &&
-                v !== null &&
-                v !== undefined &&
-                !Number.isNaN(v) &&
-                v !== 0n,
-            ),
-          fc.constantFrom(...extractPhrases(assertions.truthyAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.truthyAssertion)!,
       },
     },
   ],
@@ -861,10 +667,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(undefined),
-          fc.constantFrom(...extractPhrases(assertions.undefinedAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.undefinedAssertion)!,
       },
     },
   ],
@@ -879,10 +682,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(new WeakMap()),
-          fc.constantFrom(...extractPhrases(assertions.weakMapAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.weakMapAssertion)!,
       },
     },
   ],
@@ -897,10 +697,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(new WeakSet()),
-          fc.constantFrom(...extractPhrases(assertions.weakSetAssertion)),
-        ],
+        generators: SyncBasicGenerators.get(assertions.weakSetAssertion)!,
       },
     },
   ],

--- a/test/property/sync-esoteric.test.ts
+++ b/test/property/sync-esoteric.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import * as assertions from '../../src/assertion/impl/sync-esoteric.js';
 import { SyncEsotericAssertions } from '../../src/assertion/index.js';
 import { type AnyAssertion } from '../../src/types.js';
+import { SyncEsotericGenerators } from '../../test-data/sync-esoteric-generators.js';
 import { expect } from '../custom-assertions.js';
 import {
   type PropertyTestConfig,
@@ -44,19 +45,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant('a'),
-          fc.constantFrom(
-            ...extractPhrases(assertions.enumerablePropertyAssertion),
-          ),
-          fc.constant({}).map((obj) => {
-            Object.defineProperty(obj, 'a', {
-              enumerable: true,
-              value: 42,
-            });
-            return obj;
-          }),
-        ],
+        generators: SyncEsotericGenerators.get(
+          assertions.enumerablePropertyAssertion,
+        )!,
       },
     },
   ],
@@ -77,19 +68,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          filteredObject.map((obj) => {
-            Object.defineProperty(obj, 'a', {
-              enumerable: true,
-              value: 42,
-            });
-            return obj;
-          }),
-          fc.constantFrom(
-            ...extractPhrases(assertions.enumerablePropertyAssertion2),
-          ),
-          fc.constant('a'),
-        ],
+        generators: SyncEsotericGenerators.get(
+          assertions.enumerablePropertyAssertion2,
+        )!,
       },
     },
   ],
@@ -108,10 +89,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          filteredObject,
-          fc.constantFrom(...extractPhrases(assertions.extensibleAssertion)),
-        ],
+        generators: SyncEsotericGenerators.get(assertions.extensibleAssertion)!,
       },
     },
   ],
@@ -126,10 +104,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          filteredObject.map(Object.freeze),
-          fc.constantFrom(...extractPhrases(assertions.frozenAssertion)),
-        ],
+        generators: SyncEsotericGenerators.get(assertions.frozenAssertion)!,
       },
     },
   ],
@@ -145,10 +120,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(Object.create(null)),
-          fc.constantFrom(...extractPhrases(assertions.nullPrototypeAssertion)),
-        ],
+        generators: SyncEsotericGenerators.get(
+          assertions.nullPrototypeAssertion,
+        )!,
       },
     },
   ],
@@ -163,13 +137,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          filteredObject.map((obj) => {
-            Object.seal(obj);
-            return obj;
-          }),
-          fc.constantFrom(...extractPhrases(assertions.sealedAssertion)),
-        ],
+        generators: SyncEsotericGenerators.get(assertions.sealedAssertion)!,
       },
     },
   ],

--- a/test/property/sync-parametric.test.ts
+++ b/test/property/sync-parametric.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 import * as assertions from '../../src/assertion/impl/sync-parametric.js';
 import { SyncParametricAssertions } from '../../src/assertion/index.js';
 import { type AnyAssertion } from '../../src/types.js';
+import { SyncParametricGenerators } from '../../test-data/sync-parametric-generators.js';
 import { expect } from '../custom-assertions.js';
 import {
   type PropertyTestConfig,
@@ -13,7 +14,6 @@ import {
 import {
   extractPhrases,
   filteredAnything,
-  filteredObject,
   getVariants,
   objectFilter,
   runVariant,
@@ -56,18 +56,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .array(filteredAnything, { minLength: 1, size: 'small' })
-          .filter(objectFilter)
-          .chain((expected) =>
-            fc.tuple(
-              fc.constant(structuredClone(expected)),
-              fc.constantFrom(
-                ...extractPhrases(assertions.arrayDeepEqualAssertion),
-              ),
-              fc.constant(expected),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.arrayDeepEqualAssertion,
+        )!,
       },
     },
   ],
@@ -99,18 +90,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .array(filteredAnything, { minLength: 1, size: 'small' })
-          .filter(objectFilter)
-          .chain((expected) =>
-            fc.tuple(
-              fc.constant(structuredClone(expected)),
-              fc.constantFrom(
-                ...extractPhrases(assertions.arraySatisfiesAssertion),
-              ),
-              fc.constant(expected),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.arraySatisfiesAssertion,
+        )!,
       },
     },
   ],
@@ -132,17 +114,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ),
       },
       valid: {
-        generators: fc
-          .string()
-          .chain((expectedMessage) =>
-            fc.tuple(
-              fc.constant(new Error(expectedMessage)),
-              fc.constantFrom(
-                ...extractPhrases(assertions.errorMessageAssertion),
-              ),
-              fc.constant(expectedMessage),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.errorMessageAssertion,
+        )!,
       },
     },
   ],
@@ -168,19 +142,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .string({ maxLength: 5, minLength: 1 })
-          .map(safeRegexStringFilter)
-          .filter((message) => !!message.length)
-          .chain((message) =>
-            fc.tuple(
-              fc.constant(new Error(message)),
-              fc.constantFrom(
-                ...extractPhrases(assertions.errorMessageMatchingAssertion),
-              ),
-              fc.constant(new RegExp(escapeStringRegexp(message))),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.errorMessageMatchingAssertion,
+        )!,
       },
     },
   ],
@@ -275,14 +239,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(() => {
-            throw new Error('test error');
-          }),
-          fc.constantFrom(
-            ...extractPhrases(assertions.functionThrowsAssertion),
-          ),
-        ],
+        generators: SyncParametricGenerators.get(
+          assertions.functionThrowsAssertion,
+        )!,
       },
     },
   ],
@@ -302,15 +261,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(() => {
-            throw new Error('hello world');
-          }),
-          fc.constantFrom(
-            ...extractPhrases(assertions.functionThrowsSatisfyingAssertion),
-          ),
-          fc.constant(/hello/),
-        ],
+        generators: SyncParametricGenerators.get(
+          assertions.functionThrowsSatisfyingAssertion,
+        )!,
       },
     },
   ],
@@ -330,15 +283,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(() => {
-            throw new Error('test');
-          }),
-          fc.constantFrom(
-            ...extractPhrases(assertions.functionThrowsTypeAssertion),
-          ),
-          fc.constant(Error),
-        ],
+        generators: SyncParametricGenerators.get(
+          assertions.functionThrowsTypeAssertion,
+        )!,
       },
     },
   ],
@@ -362,19 +309,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(() => {
-            throw new Error('test message');
-          }),
-          fc.constantFrom('to throw a', 'to throw an'),
-          fc.constant(Error), // Expect Error and will get Error
-          fc.constant('satisfying'),
-          fc.constantFrom(
-            { message: 'test message' },
-            'test message',
-            /test message/,
-          ),
-        ],
+        generators: SyncParametricGenerators.get(
+          assertions.functionThrowsTypeSatisfyingAssertion,
+        )!,
       },
     },
   ],
@@ -390,11 +327,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.constant(new Error('test')),
-          fc.constantFrom(...extractPhrases(assertions.instanceOfAssertion)),
-          fc.constant(Error),
-        ],
+        generators: SyncParametricGenerators.get(
+          assertions.instanceOfAssertion,
+        )!,
       },
     },
   ],
@@ -420,21 +355,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ),
       },
       valid: {
-        generators: fc.integer({ max: 100, min: -100 }).chain((target) =>
-          fc.integer({ max: 10, min: 1 }).chain((tolerance) =>
-            fc.tuple(
-              fc.integer({
-                max: target + tolerance,
-                min: target - tolerance,
-              }),
-              fc.constantFrom(
-                ...extractPhrases(assertions.numberCloseToAssertion),
-              ),
-              fc.constant(target),
-              fc.constant(tolerance),
-            ),
-          ),
-        ),
+        generators: SyncParametricGenerators.get(
+          assertions.numberCloseToAssertion,
+        )!,
       },
     },
   ],
@@ -456,17 +379,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .integer({ max: 5, min: 1 })
-          .chain((threshold) =>
-            fc.tuple(
-              fc.integer({ max: 10, min: 6 }),
-              fc.constantFrom(
-                ...extractPhrases(assertions.numberGreaterThanAssertion),
-              ),
-              fc.constant(threshold),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.numberGreaterThanAssertion,
+        )!,
       },
     },
   ],
@@ -488,17 +403,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .integer({ max: 50, min: -50 })
-          .chain((threshold) =>
-            fc.tuple(
-              fc.integer({ min: threshold }),
-              fc.constantFrom(
-                ...extractPhrases(assertions.numberGreaterThanOrEqualAssertion),
-              ),
-              fc.constant(threshold),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.numberGreaterThanOrEqualAssertion,
+        )!,
       },
     },
   ],
@@ -520,17 +427,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .integer({ max: 50, min: -50 })
-          .chain((threshold) =>
-            fc.tuple(
-              fc.integer({ max: threshold - 1 }),
-              fc.constantFrom(
-                ...extractPhrases(assertions.numberLessThanAssertion),
-              ),
-              fc.constant(threshold),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.numberLessThanAssertion,
+        )!,
       },
     },
   ],
@@ -552,17 +451,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .integer({ max: 50, min: -50 })
-          .chain((threshold) =>
-            fc.tuple(
-              fc.integer({ max: threshold }),
-              fc.constantFrom(
-                ...extractPhrases(assertions.numberLessThanOrEqualAssertion),
-              ),
-              fc.constant(threshold),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.numberLessThanOrEqualAssertion,
+        )!,
       },
     },
   ],
@@ -588,18 +479,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ),
       },
       valid: {
-        generators: fc.integer({ max: 50, min: 0 }).chain((min) =>
-          fc.integer({ max: 100, min: min + 5 }).chain((max) =>
-            fc.tuple(
-              fc.integer({ max, min }), // Within range
-              fc.constantFrom(
-                ...extractPhrases(assertions.numberWithinRangeAssertion),
-              ),
-              fc.constant(min),
-              fc.constant(max),
-            ),
-          ),
-        ),
+        generators: SyncParametricGenerators.get(
+          assertions.numberWithinRangeAssertion,
+        )!,
       },
     },
   ],
@@ -629,18 +511,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         verbose: true,
       },
       valid: {
-        generators: fc
-          .object()
-          .filter(objectFilter)
-          .chain((expected) =>
-            fc.tuple(
-              fc.constant(structuredClone(expected)),
-              fc.constantFrom(
-                ...extractPhrases(assertions.objectDeepEqualAssertion),
-              ),
-              fc.constant(expected),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.objectDeepEqualAssertion,
+        )!,
       },
     },
   ],
@@ -670,18 +543,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         verbose: true,
       },
       valid: {
-        generators: fc
-          .object({ depthSize: 'small' })
-          .filter(objectFilter)
-          .chain((expected) =>
-            fc.tuple(
-              fc.constant(structuredClone(expected)),
-              fc.constantFrom(
-                ...extractPhrases(assertions.objectSatisfiesAssertion),
-              ),
-              fc.constant(expected),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.objectSatisfiesAssertion,
+        )!,
       },
     },
   ],
@@ -697,15 +561,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ],
       },
       valid: {
-        generators: [
-          fc.oneof(
-            fc.constant('test'),
-            fc.constant('other1'),
-            fc.constant('other2'),
-          ),
-          fc.constantFrom(...extractPhrases(assertions.oneOfAssertion)),
-          fc.constant(['test', 'other1', 'other2']),
-        ],
+        generators: SyncParametricGenerators.get(assertions.oneOfAssertion)!,
       },
     },
   ],
@@ -728,18 +584,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .anything()
-          .filter((v) => !Number.isNaN(v))
-          .chain((value) =>
-            fc.tuple(
-              fc.constant(value),
-              fc.constantFrom(
-                ...extractPhrases(assertions.strictEqualityAssertion),
-              ),
-              fc.constant(value),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.strictEqualityAssertion,
+        )!,
       },
     },
   ],
@@ -761,21 +608,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ),
       },
       valid: {
-        generators: fc
-          .string({ minLength: 2 })
-          .chain((str) =>
-            fc
-              .integer({ max: str.length, min: 1 })
-              .chain((prefixLength) =>
-                fc.tuple(
-                  fc.constant(str),
-                  fc.constantFrom(
-                    ...extractPhrases(assertions.stringBeginsWithAssertion),
-                  ),
-                  fc.constant(str.substring(0, prefixLength)),
-                ),
-              ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.stringBeginsWithAssertion,
+        )!,
       },
     },
   ],
@@ -797,21 +632,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ),
       },
       valid: {
-        generators: fc
-          .string({ minLength: 2 })
-          .chain((str) =>
-            fc
-              .integer({ max: str.length, min: 1 })
-              .chain((suffixLength) =>
-                fc.tuple(
-                  fc.constant(str),
-                  fc.constantFrom(
-                    ...extractPhrases(assertions.stringEndsWithAssertion),
-                  ),
-                  fc.constant(str.substring(str.length - suffixLength)),
-                ),
-              ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.stringEndsWithAssertion,
+        )!,
       },
     },
   ],
@@ -835,17 +658,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .string({ maxLength: 5, minLength: 1 })
-          .chain((threshold) =>
-            fc.tuple(
-              fc.constant(threshold + 'a'), // Simple: append 'a' to make it greater
-              fc.constantFrom(
-                ...extractPhrases(assertions.stringGreaterThanAssertion),
-              ),
-              fc.constant(threshold),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.stringGreaterThanAssertion,
+        )!,
       },
     },
   ],
@@ -872,20 +687,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .string({ maxLength: 5, minLength: 1 })
-          .chain((threshold) =>
-            fc.tuple(
-              fc.oneof(
-                fc.constant(threshold), // Equal case
-                fc.constant(threshold + 'a'), // Greater case: append 'a'
-              ),
-              fc.constantFrom(
-                ...extractPhrases(assertions.stringGreaterThanOrEqualAssertion),
-              ),
-              fc.constant(threshold),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.stringGreaterThanOrEqualAssertion,
+        )!,
       },
     },
   ],
@@ -907,27 +711,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
         ),
       },
       valid: {
-        generators: fc
-          .string({ minLength: 3 })
-          .chain((str) =>
-            fc
-              .integer({ max: str.length - 1, min: 1 })
-              .chain((startIndex) =>
-                fc
-                  .integer({ max: str.length - startIndex, min: 1 })
-                  .chain((length) =>
-                    fc.tuple(
-                      fc.constant(str),
-                      fc.constantFrom(
-                        ...extractPhrases(assertions.stringIncludesAssertion),
-                      ),
-                      fc.constant(
-                        str.substring(startIndex, startIndex + length),
-                      ),
-                    ),
-                  ),
-              ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.stringIncludesAssertion,
+        )!,
       },
     },
   ],
@@ -952,22 +738,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .string({ maxLength: 5, minLength: 1 })
-          .chain((threshold) =>
-            fc.tuple(
-              // Generate string guaranteed to be less than threshold
-              fc.constant(
-                threshold.length > 0 && threshold.charCodeAt(0) > 32
-                  ? ' '.repeat(threshold.length)
-                  : '',
-              ),
-              fc.constantFrom(
-                ...extractPhrases(assertions.stringLessThanAssertion),
-              ),
-              fc.constant(threshold),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.stringLessThanAssertion,
+        )!,
       },
     },
   ],
@@ -989,26 +762,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .string({ maxLength: 5, minLength: 1 })
-          .chain((threshold) =>
-            fc.tuple(
-              fc.oneof(
-                fc.constant(threshold), // Equal case
-                // Less case: if threshold starts with a character > space, replace with space
-                // Otherwise use empty string (which is always < any non-empty string)
-                fc.constant(
-                  threshold.length > 0 && threshold.charCodeAt(0) > 32
-                    ? ' '.repeat(threshold.length)
-                    : '',
-                ),
-              ),
-              fc.constantFrom(
-                ...extractPhrases(assertions.stringLessThanOrEqualAssertion),
-              ),
-              fc.constant(threshold),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.stringLessThanOrEqualAssertion,
+        )!,
       },
     },
   ],
@@ -1034,19 +790,9 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .string({ maxLength: 5, minLength: 1 })
-          .map(safeRegexStringFilter)
-          .filter((str) => !!str.length)
-          .chain((str) =>
-            fc.tuple(
-              fc.constant(str),
-              fc.constantFrom(
-                ...extractPhrases(assertions.stringMatchesAssertion),
-              ),
-              fc.constant(new RegExp(escapeStringRegexp(str))),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(
+          assertions.stringMatchesAssertion,
+        )!,
       },
     },
   ],
@@ -1087,41 +833,7 @@ const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           ),
       },
       valid: {
-        generators: fc
-          .oneof(
-            // Generate value-type pairs where value matches the type
-            fc.constant([fc.string(), 'string']),
-            fc.constant([
-              fc.float({ noDefaultInfinity: true, noNaN: true }),
-              'number',
-            ]),
-            fc.constant([fc.boolean(), 'boolean']),
-            fc.constant([fc.constant(undefined), 'undefined']),
-            fc.constant([fc.constant(null), 'null']),
-            fc.constant([fc.constant(BigInt(1)), 'bigint']),
-            fc.constant([fc.constant(Symbol('test')), 'symbol']),
-            fc.constant([filteredObject, 'object']),
-            fc.constant([fc.func(filteredAnything), 'function']),
-            fc.constant([fc.array(filteredAnything), 'array']),
-            fc.constant([fc.constant(new Date()), 'date']),
-            fc.constant([fc.constant(new Map()), 'map']),
-            fc.constant([fc.constant(new Set()), 'set']),
-            fc.constant([fc.constant(new WeakMap()), 'weakmap']),
-            fc.constant([fc.constant(new WeakSet()), 'weakset']),
-            fc.constant([fc.constant(/test/), 'regexp']),
-            fc.constant([fc.constant(Promise.resolve()), 'promise']),
-            fc.constant([fc.constant(new Error()), 'error']),
-            fc.constant([fc.constant(new WeakRef({})), 'weakref']),
-          )
-          .chain(([valueGen, typeString]) =>
-            valueGen.chain((value) =>
-              fc.tuple(
-                fc.constant(value),
-                fc.constantFrom(...extractPhrases(assertions.typeOfAssertion)),
-                fc.constant(typeString), // Only use lowercase
-              ),
-            ),
-          ),
+        generators: SyncParametricGenerators.get(assertions.typeOfAssertion)!,
       },
     },
   ],


### PR DESCRIPTION
Fixes #135

- re-organize test data for valid assertions into `test-data/`
- bespoke benchmark runner in `bench/`