### PR TITLE
fix(assertions): function bodies of std. schema assertions now correctly infer arg types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,8 @@
         "typedoc-plugin-redirect": "1.2.1",
         "typedoc-plugin-zod": "1.4.3",
         "typescript": "5.9.3",
-        "typescript-eslint": "8.46.2"
+        "typescript-eslint": "8.46.2",
+        "valibot": "1.1.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
@@ -10735,6 +10736,21 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
+      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -217,7 +217,8 @@
     "typedoc-plugin-redirect": "1.2.1",
     "typedoc-plugin-zod": "1.4.3",
     "typescript": "5.9.3",
-    "typescript-eslint": "8.46.2"
+    "typescript-eslint": "8.46.2",
+    "valibot": "1.1.0"
   },
   "publishConfig": {
     "access": "public",

--- a/test/assertion-error/valibot-error.test.ts
+++ b/test/assertion-error/valibot-error.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Snapshot tests for Valibot-based assertion errors.
+ *
+ * These tests capture the error output format from Valibot-based assertions to
+ * ensure consistent error messages and allow comparison with native bupkis
+ * (Zod-based) assertions.
+ */
+
+import { describe, it } from 'node:test';
+
+import { type AnyAssertion } from '../../src/types.js';
+import { expect } from '../custom-assertions.js';
+import {
+  valibotArrayAssertion,
+  valibotArrayContainsAssertion,
+  valibotArrayLengthAssertion,
+  valibotBooleanAssertion,
+  valibotEqualityAssertion,
+  valibotGreaterThanAssertion,
+  valibotLessThanAssertion,
+  valibotNumberAssertion,
+  valibotObjectHasPropertyAssertion,
+  valibotStringAssertion,
+  valibotStringContainsAssertion,
+} from '../valibot-assertions.js';
+import { takeErrorSnapshot } from './error-snapshot-util.js';
+
+const failingAssertions = new Map<AnyAssertion, () => void>([
+  [
+    valibotArrayAssertion,
+    () => {
+      expect(42, 'to be an array');
+    },
+  ],
+  [
+    valibotArrayContainsAssertion,
+    () => {
+      expect([1, 2, 3], 'to contain', 5);
+    },
+  ],
+  [
+    valibotArrayLengthAssertion,
+    () => {
+      expect([1, 2, 3], 'to have length', 5);
+    },
+  ],
+  [
+    valibotBooleanAssertion,
+    () => {
+      expect('hello', 'to be a boolean');
+    },
+  ],
+  [
+    valibotEqualityAssertion,
+    () => {
+      expect(5, 'to be', 10);
+    },
+  ],
+  [
+    valibotGreaterThanAssertion,
+    () => {
+      expect(3, 'to be greater than', 5);
+    },
+  ],
+  [
+    valibotLessThanAssertion,
+    () => {
+      expect(10, 'to be less than', 5);
+    },
+  ],
+  [
+    valibotNumberAssertion,
+    () => {
+      expect('hello', 'to be a number');
+    },
+  ],
+  [
+    valibotObjectHasPropertyAssertion,
+    () => {
+      expect({ foo: 'bar' }, 'to have property', 'baz');
+    },
+  ],
+  [
+    valibotStringAssertion,
+    () => {
+      expect(42, 'to be a string');
+    },
+  ],
+  [
+    valibotStringContainsAssertion,
+    () => {
+      expect('hello world', 'to contain', 'foo');
+    },
+  ],
+]);
+
+describe('Valibot Assertion Error Snapshots', () => {
+  for (const [assertion, failingFn] of failingAssertions) {
+    const { id } = assertion;
+    describe(`${assertion} [${id}]`, () => {
+      it(
+        `should throw a consistent AssertionError [${id}] <snapshot>`,
+        takeErrorSnapshot(failingFn),
+      );
+    });
+  }
+});

--- a/test/assertion-error/valibot-error.test.ts.snapshot
+++ b/test/assertion-error/valibot-error.test.ts.snapshot
@@ -1,0 +1,147 @@
+exports[`Valibot Assertion Error Snapshots > \"{custom} 'to be greater than' {custom}\" [custom-to-be-greater-than-custom-3s3p] > should throw a consistent AssertionError [custom-to-be-greater-than-custom-3s3p] <snapshot> 1`] = `
+{
+  "message": "Assertion \\"{number} 'to be greater than' {number}\\" failed:\\n\\u001b[32m- expected  - 1\\u001b[39m\\n\\u001b[31m+ actual    + 1\\u001b[39m\\n\\n\\u001b[32m- 5\\u001b[39m\\n\\u001b[31m+ 3\\u001b[39m",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": 3,
+  "expected": 5,
+  "diff": "simple",
+  "assertionId": "number-to-be-greater-than-number-3s3p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{custom} 'to be less than' {custom}\" [custom-to-be-less-than-custom-3s3p] > should throw a consistent AssertionError [custom-to-be-less-than-custom-3s3p] <snapshot> 1`] = `
+{
+  "message": "Assertion \\"{number} 'to be less than' / 'to be lt' {number}\\" failed:\\n\\u001b[32m- expected  - 1\\u001b[39m\\n\\u001b[31m+ actual    + 1\\u001b[39m\\n\\n\\u001b[32m- 5\\u001b[39m\\n\\u001b[31m+ 10\\u001b[39m",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": 10,
+  "expected": 5,
+  "diff": "simple",
+  "assertionId": "number-to-be-less-than-to-be-lt-number-3s3p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{custom} 'to be' {custom}\" [custom-to-be-custom-3s3p] > should throw a consistent AssertionError [custom-to-be-custom-3s3p] <snapshot> 1`] = `
+{
+  "message": "Expected 5 to equal 10",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": 5,
+  "expected": 10,
+  "diff": "simple",
+  "assertionId": "unknown-to-be-to-equal-equals-is-is-equal-to-to-strictly-equal-is-strictly-equal-to-unknown-3s2p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{custom} 'to contain' {custom}\" [custom-to-contain-custom-3s3p] > should throw a consistent AssertionError [custom-to-contain-custom-3s3p] <snapshot> 1`] = `
+{
+  "message": "Expected array to contain value",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "diff": "simple",
+  "assertionId": "unknown_array-to-contain-to-include-unknown-3s3p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{custom} 'to contain' {custom}\" [custom-to-contain-custom-3s3p] > should throw a consistent AssertionError [custom-to-contain-custom-3s3p] <snapshot> 2`] = `
+{
+  "message": "Expected \\"hello world\\" to include \\"foo\\"",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "diff": "simple",
+  "assertionId": "string-includes-contains-to-include-to-contain-string-3s3p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{custom} 'to have length' {custom}\" [custom-to-have-length-custom-3s3p] > should throw a consistent AssertionError [custom-to-have-length-custom-3s3p] <snapshot> 1`] = `
+{
+  "message": "Assertion \\"{unknown-array} 'to have length' / 'to have size' {nonnegative-integer}\\" failed:\\n\\u001b[32m- expected  - 2\\u001b[39m\\n\\u001b[31m+ actual    + 0\\u001b[39m\\n\\n\\u001b[2m  Array [\\u001b[22m\\n\\u001b[2m    1,\\u001b[22m\\n\\u001b[2m    2,\\u001b[22m\\n\\u001b[2m    3,\\u001b[22m\\n\\u001b[32m-   null,\\u001b[39m\\n\\u001b[32m-   null,\\u001b[39m\\n\\u001b[2m  ]\\u001b[22m",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": [
+    1,
+    2,
+    3
+  ],
+  "expected": [
+    1,
+    2,
+    3,
+    null,
+    null
+  ],
+  "diff": "simple",
+  "assertionId": "unknown_array-to-have-length-to-have-size-nonnegative_integer-3s3p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{custom} 'to have property' {custom}\" [custom-to-have-property-custom-3s3p] > should throw a consistent AssertionError [custom-to-have-property-custom-3s3p] <snapshot> 1`] = `
+{
+  "message": "Expected object to contain keypath baz",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": "no such keypath",
+  "diff": "simple",
+  "assertionId": "non_collection_object-to-have-key-to-have-property-to-have-prop-to-contain-key-to-contain-property-to-contain-prop-to-include-key-to-include-property-to-include-prop-keypath-3s3p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{unknown} 'to be a boolean'\" [unknown-to-be-a-boolean-2s1p] > should throw a consistent AssertionError [unknown-to-be-a-boolean-2s1p] <snapshot> 1`] = `
+{
+  "message": "Assertion \\"{unknown} 'to be a boolean' / 'to be boolean' / 'to be a bool'\\" failed:\\n  Comparing two different types of values. Expected \\u001b[32mboolean\\u001b[39m but received \\u001b[31mstring\\u001b[39m.",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": "hello",
+  "expected": true,
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-boolean-to-be-boolean-to-be-a-bool-2s1p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{unknown} 'to be a number'\" [unknown-to-be-a-number-2s1p] > should throw a consistent AssertionError [unknown-to-be-a-number-2s1p] <snapshot> 1`] = `
+{
+  "message": "Assertion \\"{unknown} 'to be a number' / 'to be finite'\\" failed:\\n  Comparing two different types of values. Expected \\u001b[32mnumber\\u001b[39m but received \\u001b[31mstring\\u001b[39m.",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": "hello",
+  "expected": 0,
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-number-to-be-finite-2s1p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{unknown} 'to be a string'\" [unknown-to-be-a-string-2s1p] > should throw a consistent AssertionError [unknown-to-be-a-string-2s1p] <snapshot> 1`] = `
+{
+  "message": "Assertion \\"{unknown} 'to be a string'\\" failed:\\n  Comparing two different types of values. Expected \\u001b[32mstring\\u001b[39m but received \\u001b[31mnumber\\u001b[39m.",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": 42,
+  "expected": "42",
+  "diff": "simple",
+  "assertionId": "unknown-to-be-a-string-2s1p"
+}
+`;
+
+exports[`Valibot Assertion Error Snapshots > \"{unknown} 'to be an array'\" [unknown-to-be-an-array-2s1p] > should throw a consistent AssertionError [unknown-to-be-an-array-2s1p] <snapshot> 1`] = `
+{
+  "message": "Assertion \\"{unknown} 'to be an array' / 'to be array'\\" failed:\\n  Comparing two different types of values. Expected \\u001b[32marray\\u001b[39m but received \\u001b[31mnumber\\u001b[39m.",
+  "generatedMessage": false,
+  "name": "AssertionError",
+  "code": "ERR_ASSERTION",
+  "actual": 42,
+  "expected": [],
+  "diff": "simple",
+  "assertionId": "unknown-to-be-an-array-to-be-array-2s1p"
+}
+`;

--- a/test/standard-schema/valibot.test.ts
+++ b/test/standard-schema/valibot.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Functional tests for Valibot Standard Schema interoperability.
+ *
+ * Tests that bupkis correctly handles assertions created with Valibot schemas,
+ * validating both success and failure modes.
+ */
+
+import { describe, it } from 'node:test';
+
+import { AssertionError } from '../../src/error.js';
+import { expect } from '../../src/index.js';
+import {
+  valibotArrayAssertion,
+  valibotArrayContainsAssertion,
+  valibotArrayLengthAssertion,
+  valibotBooleanAssertion,
+  valibotEqualityAssertion,
+  valibotGreaterThanAssertion,
+  valibotLessThanAssertion,
+  valibotNumberAssertion,
+  valibotObjectHasPropertyAssertion,
+  valibotStringAssertion,
+  valibotStringContainsAssertion,
+} from '../valibot-assertions.js';
+
+describe('Valibot Standard Schema - Functional Tests', () => {
+  describe('Basic Type Assertions', () => {
+    describe('string assertion', () => {
+      it('should pass with valid string', () => {
+        valibotStringAssertion.execute(['hello'], ['hello'], () => {});
+      });
+
+      it('should fail with non-string', () => {
+        try {
+          valibotStringAssertion.execute([42], [42], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+
+    describe('number assertion', () => {
+      it('should pass with valid number', () => {
+        valibotNumberAssertion.execute([42], [42], () => {});
+      });
+
+      it('should fail with non-number', () => {
+        try {
+          valibotNumberAssertion.execute(['hello'], ['hello'], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+
+      it('should fail with Infinity', () => {
+        try {
+          valibotNumberAssertion.execute([Infinity], [Infinity], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+
+    describe('boolean assertion', () => {
+      it('should pass with valid boolean', () => {
+        valibotBooleanAssertion.execute([true], [true], () => {});
+        valibotBooleanAssertion.execute([false], [false], () => {});
+      });
+
+      it('should fail with non-boolean', () => {
+        try {
+          valibotBooleanAssertion.execute([1], [1], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+
+    describe('array assertion', () => {
+      it('should pass with valid array', () => {
+        valibotArrayAssertion.execute([[1, 2, 3]], [[1, 2, 3]], () => {});
+        valibotArrayAssertion.execute([[]], [[]], () => {});
+      });
+
+      it('should fail with non-array', () => {
+        try {
+          valibotArrayAssertion.execute(
+            [{ foo: 'bar' }],
+            [{ foo: 'bar' }],
+            () => {},
+          );
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+  });
+
+  describe('Parametric Assertions', () => {
+    describe('equality assertion', () => {
+      it('should pass with equal values', () => {
+        valibotEqualityAssertion.execute([5, 5], [5, 5], () => {});
+        valibotEqualityAssertion.execute(
+          ['hello', 'hello'],
+          ['hello', 'hello'],
+          () => {},
+        );
+      });
+
+      it('should fail with unequal values', () => {
+        try {
+          valibotEqualityAssertion.execute([5, 10], [5, 10], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+
+    describe('greater than assertion', () => {
+      it('should pass when subject is greater', () => {
+        valibotGreaterThanAssertion.execute([10, 5], [10, 5], () => {});
+      });
+
+      it('should fail when subject is not greater', () => {
+        try {
+          valibotGreaterThanAssertion.execute([3, 5], [3, 5], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+
+      it('should fail when subject equals expected', () => {
+        try {
+          valibotGreaterThanAssertion.execute([5, 5], [5, 5], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+
+    describe('less than assertion', () => {
+      it('should pass when subject is less', () => {
+        valibotLessThanAssertion.execute([3, 10], [3, 10], () => {});
+      });
+
+      it('should fail when subject is not less', () => {
+        try {
+          valibotLessThanAssertion.execute([10, 5], [10, 5], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+
+      it('should fail when subject equals expected', () => {
+        try {
+          valibotLessThanAssertion.execute([5, 5], [5, 5], () => {});
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+
+    describe('string contains assertion', () => {
+      it('should pass when string contains substring', () => {
+        valibotStringContainsAssertion.execute(
+          ['hello world', 'world'],
+          ['hello world', 'world'],
+          () => {},
+        );
+      });
+
+      it('should fail when string does not contain substring', () => {
+        try {
+          valibotStringContainsAssertion.execute(
+            ['hello world', 'foo'],
+            ['hello world', 'foo'],
+            () => {},
+          );
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+
+    describe('array length assertion', () => {
+      it('should pass with correct length', () => {
+        valibotArrayLengthAssertion.execute(
+          [[1, 2, 3], 3],
+          [[1, 2, 3], 3],
+          () => {},
+        );
+      });
+
+      it('should fail with incorrect length', () => {
+        try {
+          valibotArrayLengthAssertion.execute(
+            [[1, 2, 3], 5],
+            [[1, 2, 3], 5],
+            () => {},
+          );
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+  });
+
+  describe('Collection Assertions', () => {
+    describe('object has property assertion', () => {
+      it('should pass when object has property', () => {
+        valibotObjectHasPropertyAssertion.execute(
+          [{ foo: 'bar' }, 'foo'],
+          [{ foo: 'bar' }, 'foo'],
+          () => {},
+        );
+      });
+
+      it('should fail when object lacks property', () => {
+        try {
+          valibotObjectHasPropertyAssertion.execute(
+            [{ foo: 'bar' }, 'baz'],
+            [{ foo: 'bar' }, 'baz'],
+            () => {},
+          );
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+
+    describe('array contains assertion', () => {
+      it('should pass when array contains value', () => {
+        valibotArrayContainsAssertion.execute(
+          [[1, 2, 3], 2],
+          [[1, 2, 3], 2],
+          () => {},
+        );
+      });
+
+      it('should fail when array does not contain value', () => {
+        try {
+          valibotArrayContainsAssertion.execute(
+            [[1, 2, 3], 5],
+            [[1, 2, 3], 5],
+            () => {},
+          );
+          expect.fail('Should have thrown AssertionError');
+        } catch (err) {
+          expect(err, 'to be an', AssertionError);
+        }
+      });
+    });
+  });
+
+  describe('Integration with native expect()', () => {
+    it('should work when used via expect() API with string assertion', () => {
+      expect('hello', 'to be a string');
+    });
+
+    it('should work when used via expect() API with greater than', () => {
+      expect(10, 'to be greater than', 5);
+    });
+
+    it('should throw AssertionError via expect() API on failure', () => {
+      try {
+        expect(5, 'to be greater than', 10);
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err, 'to be an', AssertionError);
+      }
+    });
+  });
+});

--- a/test/valibot-assertions.ts
+++ b/test/valibot-assertions.ts
@@ -1,0 +1,119 @@
+/**
+ * Valibot-based assertion definitions for Standard Schema interoperability
+ * testing.
+ *
+ * These assertions mirror native bupkis assertions but use Valibot schemas
+ * instead of Zod to validate Standard Schema v1 compatibility.
+ */
+
+import * as v from 'valibot';
+
+import { createAssertion } from '../src/assertion/create.js';
+
+export const valibotStringAssertion = createAssertion(
+  ['to be a string'],
+  v.string(),
+);
+
+export const valibotNumberAssertion = createAssertion(
+  ['to be a number'],
+  v.pipe(v.number(), v.finite()),
+);
+
+export const valibotBooleanAssertion = createAssertion(
+  ['to be a boolean'],
+  v.boolean(),
+);
+
+export const valibotArrayAssertion = createAssertion(
+  ['to be an array'],
+  v.array(v.unknown()),
+);
+
+export const valibotEqualityAssertion = createAssertion(
+  [v.unknown(), 'to be', v.unknown()],
+  (subject, expected) => {
+    if (subject !== expected) {
+      return {
+        actual: subject,
+        expected,
+        message: `Expected values to be strictly equal`,
+      };
+    }
+  },
+);
+
+export const valibotGreaterThanAssertion = createAssertion(
+  [v.number(), 'to be greater than', v.number()],
+  (_, expected) => v.pipe(v.number(), v.minValue(expected + 1)),
+);
+
+export const valibotLessThanAssertion = createAssertion(
+  [v.number(), 'to be less than', v.number()],
+  (_, expected) => v.pipe(v.number(), v.maxValue(expected - 1)),
+);
+
+export const valibotStringContainsAssertion = createAssertion(
+  [v.string(), 'to contain', v.string()],
+  (subject, expected) => {
+    if (!subject.includes(expected)) {
+      return {
+        message: `Expected "${subject}" to include "${expected}"`,
+      };
+    }
+  },
+);
+
+export const valibotArrayLengthAssertion = createAssertion(
+  [
+    v.array(v.unknown()),
+    'to have length',
+    v.pipe(v.number(), v.integer(), v.minValue(0)),
+  ],
+  (_, expectedLength) =>
+    v.pipe(
+      v.array(v.unknown()),
+      v.minLength(expectedLength),
+      v.maxLength(expectedLength),
+    ),
+);
+
+export const valibotObjectHasPropertyAssertion = createAssertion(
+  [v.object({}), 'to have property', v.string()],
+  (subject, key) => {
+    if (!(key in subject)) {
+      return {
+        actual: 'no such property',
+        expected: `to have property ${key}`,
+        message: `Expected object to contain property "${key}"`,
+      };
+    }
+  },
+);
+
+export const valibotArrayContainsAssertion = createAssertion(
+  [v.array(v.unknown()), 'to contain', v.unknown()],
+  (subject, expected) => {
+    if (!subject.includes(expected)) {
+      return {
+        actual: subject,
+        expected: `array containing ${String(expected)}`,
+        message: `Expected array to contain value`,
+      };
+    }
+  },
+);
+
+export const ALL_VALIBOT_ASSERTIONS = [
+  valibotStringAssertion,
+  valibotNumberAssertion,
+  valibotBooleanAssertion,
+  valibotArrayAssertion,
+  valibotEqualityAssertion,
+  valibotGreaterThanAssertion,
+  valibotLessThanAssertion,
+  valibotStringContainsAssertion,
+  valibotArrayLengthAssertion,
+  valibotObjectHasPropertyAssertion,
+  valibotArrayContainsAssertion,
+] as const;


### PR DESCRIPTION
Added valibot for integration tests with another standard-schema-supporting lib.