### PR TITLE
chore: simplify and deduplicate assertion code

### DIFF
--- a/src/assertion/assertion-async.ts
+++ b/src/assertion/assertion-async.ts
@@ -1,7 +1,6 @@
 import { inspect } from 'util';
 import z from 'zod/v4';
 
-import { kStringLiteral } from '../constant.js';
 import { AssertionError, AssertionImplementationError } from '../error.js';
 import {
   isA,
@@ -14,7 +13,6 @@ import {
   isAssertionFailure,
   isAssertionParseRequest,
 } from '../internal-schema.js';
-import { BupkisRegistry } from '../metadata.js';
 import {
   type AssertionAsync,
   type AssertionFunctionAsync,
@@ -32,10 +30,10 @@ import {
 import { BupkisAssertion } from './assertion.js';
 
 export abstract class BupkisAssertionAsync<
-    Parts extends AssertionParts,
-    Impl extends AssertionImplAsync<Parts>,
-    Slots extends AssertionSlots<Parts>,
-  >
+  Parts extends AssertionParts,
+  Impl extends AssertionImplAsync<Parts>,
+  Slots extends AssertionSlots<Parts>,
+>
   extends BupkisAssertion<Parts, Impl, Slots>
   implements AssertionAsync<Parts, Impl, Slots>
 {
@@ -106,10 +104,10 @@ export abstract class BupkisAssertionAsync<
  */
 
 export class BupkisAssertionFunctionAsync<
-    Parts extends AssertionParts,
-    Impl extends AssertionImplFnAsync<Parts>,
-    Slots extends AssertionSlots<Parts>,
-  >
+  Parts extends AssertionParts,
+  Impl extends AssertionImplFnAsync<Parts>,
+  Slots extends AssertionSlots<Parts>,
+>
   extends BupkisAssertionAsync<Parts, Impl, Slots>
   implements AssertionFunctionAsync<Parts, Impl, Slots>
 {
@@ -231,10 +229,10 @@ export class BupkisAssertionFunctionAsync<
  */
 
 export class BupkisAssertionSchemaAsync<
-    Parts extends AssertionParts,
-    Impl extends AssertionImplSchemaAsync<Parts>,
-    Slots extends AssertionSlots<Parts>,
-  >
+  Parts extends AssertionParts,
+  Impl extends AssertionImplSchemaAsync<Parts>,
+  Slots extends AssertionSlots<Parts>,
+>
   extends BupkisAssertionAsync<Parts, Impl, Slots>
   implements AssertionSchemaAsync<Parts, Impl, Slots>
 {
@@ -346,26 +344,5 @@ export class BupkisAssertionSchemaAsync<
     }
 
     return result;
-  }
-
-  /**
-   * Determines if this assertion can be optimized (simple single-subject
-   * schema). Only simple assertions like ['to be a string'] with z.string()
-   * qualify.
-   */
-  private isSimpleSchemaAssertion(): boolean {
-    // Only optimize if we have exactly one subject slot + string literal slots
-    // and no complex argument processing
-    const hasSubjectSlot =
-      this.slots.length > 0 &&
-      (this.slots[0]?.def.type === 'unknown' ||
-        this.slots[0]?.def.type === 'any');
-
-    const allOtherSlotsAreLiterals = this.slots.slice(1).every((slot) => {
-      const meta = BupkisRegistry.get(slot) ?? {};
-      return kStringLiteral in meta;
-    });
-
-    return hasSubjectSlot && allOtherSlotsAreLiterals;
   }
 }

--- a/src/assertion/assertion-standard-schema-async.ts
+++ b/src/assertion/assertion-standard-schema-async.ts
@@ -18,8 +18,6 @@ import type {
   ParsedValues,
 } from './assertion-types.js';
 
-import { kStringLiteral } from '../constant.js';
-import { BupkisRegistry } from '../metadata.js';
 import { BupkisAssertion } from './assertion.js';
 
 /**
@@ -35,10 +33,10 @@ import { BupkisAssertion } from './assertion.js';
  * @template Slots - The derived validation slots
  */
 export class BupkisAssertionStandardSchemaAsync<
-    Parts extends AssertionParts,
-    Impl extends StandardSchemaV1,
-    Slots extends AssertionSlots<Parts>,
-  >
+  Parts extends AssertionParts,
+  Impl extends StandardSchemaV1,
+  Slots extends AssertionSlots<Parts>,
+>
   extends BupkisAssertion<Parts, Impl, Slots>
   implements AssertionStandardSchemaAsync<Parts, Impl, Slots>
 {
@@ -173,30 +171,5 @@ export class BupkisAssertionStandardSchemaAsync<
     }
 
     return result;
-  }
-
-  /**
-   * Determines if this is a simple schema assertion eligible for optimization.
-   *
-   * Returns true when the assertion has:
-   *
-   * - Exactly one subject slot (unknown/any type)
-   * - Only phrase literal slots after the subject
-   * - No complex argument processing
-   *
-   * @returns True if optimization can be applied
-   */
-  private isSimpleSchemaAssertion(): boolean {
-    const hasSubjectSlot =
-      this.slots.length > 0 &&
-      (this.slots[0]?.def.type === 'unknown' ||
-        this.slots[0]?.def.type === 'any');
-
-    const allOtherSlotsAreLiterals = this.slots.slice(1).every((slot) => {
-      const meta = BupkisRegistry.get(slot) ?? {};
-      return kStringLiteral in meta;
-    });
-
-    return hasSubjectSlot && allOtherSlotsAreLiterals;
   }
 }

--- a/src/assertion/assertion-standard-schema-sync.ts
+++ b/src/assertion/assertion-standard-schema-sync.ts
@@ -18,8 +18,6 @@ import type {
   ParsedValues,
 } from './assertion-types.js';
 
-import { kStringLiteral } from '../constant.js';
-import { BupkisRegistry } from '../metadata.js';
 import { BupkisAssertion } from './assertion.js';
 
 /**
@@ -35,10 +33,10 @@ import { BupkisAssertion } from './assertion.js';
  * @template Slots - The derived validation slots
  */
 export class BupkisAssertionStandardSchemaSync<
-    Parts extends AssertionParts,
-    Impl extends StandardSchemaV1,
-    Slots extends AssertionSlots<Parts>,
-  >
+  Parts extends AssertionParts,
+  Impl extends StandardSchemaV1,
+  Slots extends AssertionSlots<Parts>,
+>
   extends BupkisAssertion<Parts, Impl, Slots>
   implements AssertionStandardSchemaSync<Parts, Impl, Slots>
 {
@@ -185,30 +183,5 @@ export class BupkisAssertionStandardSchemaSync<
     }
 
     return result;
-  }
-
-  /**
-   * Determines if this is a simple schema assertion eligible for optimization.
-   *
-   * Returns true when the assertion has:
-   *
-   * - Exactly one subject slot (unknown/any type)
-   * - Only phrase literal slots after the subject
-   * - No complex argument processing
-   *
-   * @returns True if optimization can be applied
-   */
-  private isSimpleSchemaAssertion(): boolean {
-    const hasSubjectSlot =
-      this.slots.length > 0 &&
-      (this.slots[0]?.def.type === 'unknown' ||
-        this.slots[0]?.def.type === 'any');
-
-    const allOtherSlotsAreLiterals = this.slots.slice(1).every((slot) => {
-      const meta = BupkisRegistry.get(slot) ?? {};
-      return kStringLiteral in meta;
-    });
-
-    return hasSubjectSlot && allOtherSlotsAreLiterals;
   }
 }

--- a/src/assertion/assertion-sync.ts
+++ b/src/assertion/assertion-sync.ts
@@ -10,7 +10,6 @@ import createDebug from 'debug';
 import { inspect } from 'util';
 import { z } from 'zod/v4';
 
-import { kStringLiteral } from '../constant.js';
 import {
   AssertionError,
   AssertionImplementationError,
@@ -27,7 +26,6 @@ import {
   isAssertionFailure,
   isAssertionParseRequest,
 } from '../internal-schema.js';
-import { BupkisRegistry } from '../metadata.js';
 import {
   type AssertionFunctionSync,
   type AssertionImplFnReturnType,
@@ -52,10 +50,10 @@ const debug = createDebug('bupkis:assertion:sync');
  * Child classes are expected to implement {@link execute}.
  */
 export abstract class BupkisAssertionSync<
-    Parts extends AssertionParts,
-    Impl extends AssertionImplSync<Parts>,
-    Slots extends AssertionSlots<Parts>,
-  >
+  Parts extends AssertionParts,
+  Impl extends AssertionImplSync<Parts>,
+  Slots extends AssertionSlots<Parts>,
+>
   extends BupkisAssertion<Parts, Impl, Slots>
   implements AssertionSync<Parts, Impl, Slots>
 {
@@ -137,10 +135,10 @@ export abstract class BupkisAssertionSync<
 }
 
 export class BupkisAssertionFunctionSync<
-    Parts extends AssertionParts,
-    Impl extends AssertionImplFnSync<Parts>,
-    Slots extends AssertionSlots<Parts>,
-  >
+  Parts extends AssertionParts,
+  Impl extends AssertionImplFnSync<Parts>,
+  Slots extends AssertionSlots<Parts>,
+>
   extends BupkisAssertionSync<Parts, Impl, Slots>
   implements AssertionFunctionSync<Parts, Impl, Slots>
 {
@@ -278,10 +276,10 @@ export class BupkisAssertionFunctionSync<
  */
 
 export class BupkisAssertionSchemaSync<
-    Parts extends AssertionParts,
-    Impl extends AssertionImplSchemaSync<Parts>,
-    Slots extends AssertionSlots<Parts>,
-  >
+  Parts extends AssertionParts,
+  Impl extends AssertionImplSchemaSync<Parts>,
+  Slots extends AssertionSlots<Parts>,
+>
   extends BupkisAssertionSync<Parts, Impl, Slots>
   implements AssertionSchemaSync<Parts, Impl, Slots>
 {
@@ -393,26 +391,5 @@ export class BupkisAssertionSchemaSync<
     }
 
     return result;
-  }
-
-  /**
-   * Determines if this assertion can be optimized (simple single-subject
-   * schema). Only simple assertions like ['to be a string'] with z.string()
-   * qualify.
-   */
-  private isSimpleSchemaAssertion(): boolean {
-    // Only optimize if we have exactly one subject slot + string literal slots
-    // and no complex argument processing
-    const hasSubjectSlot =
-      this.slots.length > 0 &&
-      (this.slots[0]?.def.type === 'unknown' ||
-        this.slots[0]?.def.type === 'any');
-
-    const allOtherSlotsAreLiterals = this.slots.slice(1).every((slot) => {
-      const meta = BupkisRegistry.get(slot) ?? {};
-      return kStringLiteral in meta;
-    });
-
-    return hasSubjectSlot && allOtherSlotsAreLiterals;
   }
 }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -374,48 +374,39 @@ const setValueAtPath = (
     obj = typeof path[0] === 'number' ? [] : {};
   }
 
-  if (isArray(obj)) {
-    const result = [...(obj as unknown[])];
-    const [head, ...tail] = path;
+  const [head, ...tail] = path;
+  if (head === undefined) {
+    return obj;
+  }
 
-    if (head !== undefined) {
-      if (tail.length === 0) {
-        result[head as number] = value;
-      } else {
-        result[head as number] = setValueAtPath(
-          result[head as number],
+  const newValue =
+    tail.length === 0
+      ? value
+      : setValueAtPath(
+          (obj as Record<number | string, unknown>)[head],
           tail,
           value,
         );
-      }
-    }
 
-    return result;
-  } else {
-    let result: Record<number | string, unknown>;
-
-    if (obj instanceof Error) {
-      result = {};
-      for (const prop of getOwnPropertyNames(obj)) {
-        if (prop !== 'stack') {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          result[prop] = (obj as any)[prop];
-        }
-      }
-    } else {
-      result = { ...(obj as Record<string, unknown>) };
-    }
-
-    const [head, ...tail] = path;
-
-    if (head !== undefined) {
-      if (tail.length === 0) {
-        result[head] = value;
-      } else {
-        result[head] = setValueAtPath(result[head], tail, value);
-      }
-    }
-
+  if (isArray(obj)) {
+    const result = [...(obj as unknown[])];
+    result[head as number] = newValue;
     return result;
   }
+
+  let result: Record<number | string, unknown>;
+  if (obj instanceof Error) {
+    result = {};
+    for (const prop of getOwnPropertyNames(obj)) {
+      if (prop !== 'stack') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        result[prop] = (obj as any)[prop];
+      }
+    }
+  } else {
+    result = { ...(obj as Record<string, unknown>) };
+  }
+
+  result[head] = newValue;
+  return result;
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -955,6 +955,36 @@ export const DurationFormatSchema = z
  *
  * @group Schema
  */
+/**
+ * Duration unit multipliers in milliseconds. Units are stored lowercase for
+ * case-insensitive matching.
+ */
+const DURATION_MULTIPLIERS: Record<string, number> = {
+  d: 24 * 60 * 60 * 1000,
+  day: 24 * 60 * 60 * 1000,
+  days: 24 * 60 * 60 * 1000,
+  h: 60 * 60 * 1000,
+  hour: 60 * 60 * 1000,
+  hours: 60 * 60 * 1000,
+  m: 60 * 1000,
+  millisecond: 1,
+  milliseconds: 1,
+  minute: 60 * 1000,
+  minutes: 60 * 1000,
+  month: 30 * 24 * 60 * 60 * 1000, // Approximate
+  months: 30 * 24 * 60 * 60 * 1000, // Approximate
+  ms: 1,
+  s: 1000,
+  second: 1000,
+  seconds: 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+  weeks: 7 * 24 * 60 * 60 * 1000,
+  y: 365 * 24 * 60 * 60 * 1000, // Approximate
+  year: 365 * 24 * 60 * 60 * 1000, // Approximate
+  years: 365 * 24 * 60 * 60 * 1000, // Approximate
+};
+
 export const DurationSchema = DurationFormatSchema.transform(
   (duration: string): number => {
     const match = duration.trim().match(DURATION_REGEX);
@@ -965,42 +995,13 @@ export const DurationSchema = DurationFormatSchema.transform(
 
     const [, amountStr, unit] = match;
     const amount = parseInt(amountStr!, 10);
+    const multiplier = DURATION_MULTIPLIERS[unit!.toLowerCase()];
 
-    switch (unit!.toLowerCase()) {
-      case 'd':
-      case 'day':
-      case 'days':
-        return amount * 24 * 60 * 60 * 1000;
-      case 'h':
-      case 'hour':
-      case 'hours':
-        return amount * 60 * 60 * 1000;
-      case 'm':
-      case 'minute':
-      case 'minutes':
-        return amount * 60 * 1000;
-      case 'millisecond':
-      case 'milliseconds':
-      case 'ms':
-        return amount;
-      case 'month':
-      case 'months':
-        return amount * 30 * 24 * 60 * 60 * 1000; // Approximate
-      case 's':
-      case 'second':
-      case 'seconds':
-        return amount * 1000;
-      case 'w':
-      case 'week':
-      case 'weeks':
-        return amount * 7 * 24 * 60 * 60 * 1000;
-      case 'y':
-      case 'year':
-      case 'years':
-        return amount * 365 * 24 * 60 * 60 * 1000; // Approximate
-      default:
-        throw new Error(`Unrecognized duration unit: ${unit}`); // Should never happen
+    if (multiplier === undefined) {
+      throw new Error(`Unrecognized duration unit: ${unit}`); // Should never happen
     }
+
+    return amount * multiplier;
   },
 )
   .register(BupkisRegistry, { name: 'duration' })


### PR DESCRIPTION
- Extract isSimpleSchemaAssertion to base BupkisAssertion class
- Extract handleAssertionError and throwNegatedAssertionPassedError helpers
- Extract generateRejoinPermutations to eliminate sync/async duplication
- Replace DurationSchema switch statement with DURATION_MULTIPLIERS lookup map
- Simplify setValueAtPath by consolidating array/object update paths
- Simplify createBaseExpect with single ternary expression
- Remove unused imports (kStringLiteral, BupkisRegistry) from subclasses

Co-Authored-By: Claude <noreply@anthropic.com>