### PR TITLE
chore!: drop support for Node.js v20.x

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -19,9 +19,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/prepare
-      - name: Run commitlint
-        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
+      - name: Validate PR commits with commitlint
         env:
-          NODE_PATH: ${{ github.workspace }}/node_modules
+          FROM_SHA: ${{ github.event.pull_request.base.sha }}
+          TO_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npx commitlint --from "$FROM_SHA" --to "$TO_SHA" --verbose

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -72,8 +72,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - node-version: '^20.19.0'
-          - node-version: '^22.12.0'
+          - node-version: '^22.13.0'
           - node-version: '^24.0.0'
           - node-version: '^26.0.0'
     steps:
@@ -85,10 +84,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm run build
-      - name: Test (Node v20.x)
-        if: startsWith(matrix.node-version, '^20')
-        # CAUTION: this only works in POSIX environments
-        run: npm run test:node20
       - name: Test
-        if: ${{ !startsWith(matrix.node-version, '^20') }}
         run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "zshy": "0.7.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       }
     },
     "node_modules/@ark/schema": {
@@ -17321,7 +17321,7 @@
         "type-fest": "^4.41.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       },
       "optionalDependencies": {
         "zod": "^4.1.5"
@@ -17339,7 +17339,7 @@
         "ts-morph": "^28.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       }
     },
     "packages/codemod-core/node_modules/@boneskull/bargs": {
@@ -17359,7 +17359,7 @@
         "eventemitter3": "5.0.4"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       },
       "peerDependencies": {
         "bupkis": ">=0.15.0"
@@ -17379,7 +17379,7 @@
       },
       "devDependencies": {},
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       }
     },
     "packages/from-assert/node_modules/@boneskull/bargs": {
@@ -17408,7 +17408,7 @@
         "chai-as-promised": "8.0.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       }
     },
     "packages/from-chai/node_modules/@boneskull/bargs": {
@@ -17440,7 +17440,7 @@
         "vitest": "4.1.9"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       }
     },
     "packages/from-jest/node_modules/@boneskull/bargs": {
@@ -17457,7 +17457,7 @@
       "version": "0.1.1",
       "license": "BlueOak-1.0.0",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       },
       "peerDependencies": {
         "bupkis": ">=0.15.0"
@@ -17471,7 +17471,7 @@
         "msw": "2.14.6"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       },
       "peerDependencies": {
         "bupkis": ">=0.15.0",
@@ -17486,7 +17486,7 @@
         "zod": "4.4.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       },
       "peerDependencies": {
         "bupkis": ">=0.15.0",
@@ -17501,7 +17501,7 @@
         "rxjs": "7.8.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       },
       "peerDependencies": {
         "bupkis": ">=0.15.0",
@@ -17517,7 +17517,7 @@
         "sinon": "21.1.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": "^22.12.0 || >=23"
       },
       "peerDependencies": {
         "bupkis": ">=0.15.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "scripts": {
     "bench": "npm run bench --workspaces --if-present",
@@ -35,7 +35,6 @@
     "test:coverage": "npm run test:coverage --workspaces --if-present",
     "test:dev": "npm run test:dev --workspaces --if-present",
     "test:fuzz": "npm run test:fuzz --workspace=bupkis",
-    "test:node20": "npm run test:node20 --workspaces",
     "test:property": "npm run test:property --workspaces --if-present",
     "test:snapshots": "npm run test:snapshots --workspaces --if-present",
     "test:types": "npm run test:types --workspaces --if-present"

--- a/packages/bupkis/README.md
+++ b/packages/bupkis/README.md
@@ -221,7 +221,7 @@ We have tried to make <strong><span class="bupkis">BUPKIS</span></strong> is as 
 
 ## Prerequisites
 
-**Node.js**: ^20.19.0, ^22.12.0, >=23
+**Node.js**: ^22.13.0, >=24.0.0
 
 <strong><span class="bupkis">BUPKIS</span></strong> supports any [Standard Schema V1][standard schema]-compliant validation library. It has a peer dependency on [Zod][] v4+ (which implements Standard Schema V1), but will install it as an optional dependency if you are not already using it. You can also use [Valibot][], [ArkType][], [Effect Schema][], or any other Standard Schema V1 library.
 

--- a/packages/bupkis/package.json
+++ b/packages/bupkis/package.json
@@ -15,7 +15,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
@@ -108,8 +108,6 @@
     "test:coverage": "c8 --reporter=lcov --reporter=text npm test",
     "test:dev": "run-s \"test:base -- --watch \\\"test/**/*.test.ts\\\"\"",
     "test:fuzz": "node --import tsx --no-warnings scripts/fuzz.ts",
-    "test:node20": "run-s test:node20:runtime test:types",
-    "test:node20:runtime": "node --test --test-reporter=spec --import tsx test/**/*.test.ts",
     "test:profile": "run-s \"test:base -- --cpu-prof --cpu-prof-dir=.profiles  \\\"test/**/*.test.ts\\\"\"",
     "test:property": "run-s \"test:base -- \\\"test/property/*.test.ts\\\"\"",
     "test:property:dev": "run-s \"test:base -- --watch \\\"test/property/*.test.ts\\\"\"",

--- a/packages/codemod-core/package.json
+++ b/packages/codemod-core/package.json
@@ -15,7 +15,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "exports": {
     ".": {
@@ -39,8 +39,7 @@
     "build": "tsc",
     "test": "npm run test:base -- \"test/*.test.ts\"",
     "test:base": "node --test --test-reporter=spec --import tsx",
-    "test:dev": "npm run test:base -- --watch \"test/*.test.ts\"",
-    "test:node20": "npm run test:base -- test/*.test.ts"
+    "test:dev": "npm run test:base -- --watch \"test/*.test.ts\""
   },
   "dependencies": {
     "@boneskull/bargs": "4.1.0",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -14,7 +14,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
@@ -47,7 +47,6 @@
     "test": "npm run test:base -- \"test/*.test.ts\"",
     "test:base": "node --import tsx --test --test-reporter=spec",
     "test:dev": "npm run test:base -- --watch \"test/*.test.ts\"",
-    "test:node20": "npm run test:base -- test/*.test.ts",
     "test:types": "tsd"
   },
   "peerDependencies": {

--- a/packages/from-assert/package.json
+++ b/packages/from-assert/package.json
@@ -15,7 +15,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "bin": {
     "bupkis-from-assert": "./dist/cli.js"
@@ -44,8 +44,7 @@
     "build": "tsc",
     "test": "npm run test:base -- \"test/**/*.test.ts\"",
     "test:base": "node --test --test-reporter=spec --import tsx",
-    "test:dev": "npm run test:base -- --watch \"test/**/*.test.ts\"",
-    "test:node20": "npm run test:base -- test/**/*.test.ts"
+    "test:dev": "npm run test:base -- --watch \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@boneskull/bargs": "4.1.0",

--- a/packages/from-chai/package.json
+++ b/packages/from-chai/package.json
@@ -15,7 +15,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "bin": {
     "bupkis-from-chai": "./dist/cli.js"
@@ -43,8 +43,7 @@
     "build": "tsc",
     "test": "npm run test:base -- \"test/**/*.test.ts\"",
     "test:base": "node --test --test-reporter=spec --import tsx",
-    "test:dev": "npm run test:base -- --watch \"test/**/*.test.ts\"",
-    "test:node20": "npm run test:base -- test/**/*.test.ts"
+    "test:dev": "npm run test:base -- --watch \"test/**/*.test.ts\""
   },
   "dependencies": {
     "@boneskull/bargs": "4.1.0",

--- a/packages/from-jest/package.json
+++ b/packages/from-jest/package.json
@@ -15,7 +15,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "bin": {
     "bupkis-from-jest": "./dist/cli.js"
@@ -47,8 +47,7 @@
     "example:vitest": "vitest run examples/vitest-example.test.ts examples/vitest-example.transformed.test.ts",
     "test": "npm run test:base -- \"test/*/*.test.ts\"",
     "test:base": "node --test --test-reporter=spec --import tsx",
-    "test:dev": "npm run test:base -- --watch \"test/*/*.test.ts\"",
-    "test:node20": "npm run test:base -- test/*.test.ts"
+    "test:dev": "npm run test:base -- --watch \"test/*/*.test.ts\""
   },
   "dependencies": {
     "@boneskull/bargs": "4.1.0",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -14,7 +14,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
@@ -48,8 +48,7 @@
     "test": "npm run test:base -- \"test/*.test.ts\"",
     "test:base": "node --import tsx --test --test-reporter=spec",
     "test:dev": "npm run test:base -- --watch \"test/*.test.ts\"",
-    "test:manual": "tsx examples/manual-test.ts",
-    "test:node20": "npm run test:base -- test/*.test.ts"
+    "test:manual": "tsx examples/manual-test.ts"
   },
   "peerDependencies": {
     "bupkis": ">=0.15.0"

--- a/packages/msw/package.json
+++ b/packages/msw/package.json
@@ -14,16 +14,16 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "module": "./dist/index.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.cts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.cts"
     },
     "./package.json": "./package.json"
   },
@@ -48,9 +48,7 @@
     "prepublishOnly": "npm run build",
     "test": "npm run test:base -- \"test/*.test.ts\"",
     "test:base": "node --import tsx --test --test-reporter=spec",
-    "test:dev": "npm run test:base -- --watch \"test/*.test.ts\"",
-    "test:node20": "npm run test:base -- test/*.test.ts",
-    "test:types": "exit 0"
+    "test:dev": "npm run test:base -- --watch \"test/*.test.ts\""
   },
   "peerDependencies": {
     "bupkis": ">=0.15.0",

--- a/packages/property-testing/package.json
+++ b/packages/property-testing/package.json
@@ -15,7 +15,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.12.0 || >=23"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
@@ -42,9 +42,7 @@
   "scripts": {
     "build": "zshy",
     "test": "npm run test:base -- \"test/*.test.ts\"",
-    "test:base": "node --test --test-reporter=spec --import tsx",
-    "test:node20": "npm run test:base -- test/*.test.ts",
-    "test:types": "echo \"No type tests yet\""
+    "test:base": "node --test --test-reporter=spec --import tsx"
   },
   "peerDependencies": {
     "bupkis": ">=0.15.0",

--- a/packages/rxjs/package.json
+++ b/packages/rxjs/package.json
@@ -14,7 +14,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
@@ -47,7 +47,6 @@
     "test": "npm run test:base -- \"test/*.test.ts\"",
     "test:base": "node --import tsx --test --test-reporter=spec",
     "test:dev": "npm run test:base -- --watch \"test/*.test.ts\"",
-    "test:node20": "npm run test:base -- test/*.test.ts",
     "test:types": "tsd"
   },
   "peerDependencies": {

--- a/packages/sinon/package.json
+++ b/packages/sinon/package.json
@@ -14,7 +14,7 @@
   },
   "license": "BlueOak-1.0.0",
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=23"
+    "node": "^22.13.0 || >=24.0.0"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
@@ -48,9 +48,7 @@
     "test": "npm run test:base -- \"test/*.test.ts\"",
     "test:base": "node --import tsx --test --test-reporter=spec",
     "test:dev": "npm run test:base -- --watch \"test/*.test.ts\"",
-    "test:node20": "npm run test:base -- test/*.test.ts",
-    "test:property": "npm run test:base -- ./test/property.test.ts",
-    "test:types": "exit 0"
+    "test:property": "npm run test:base -- ./test/property.test.ts"
   },
   "peerDependencies": {
     "bupkis": ">=0.15.0",

--- a/site/guide/usage.md
+++ b/site/guide/usage.md
@@ -17,7 +17,7 @@ npm install bupkis -D
 
 ### Prerequisites
 
-<span class="bupkis">BUPKIS</span> requires Node.js version **^20.19.0 || ^22.12.0 || >=23**. Take it or leave it.
+<span class="bupkis">BUPKIS</span> requires Node.js version **^22.13.0 || >=24.0.0**. Take it or leave it.
 
 The library supports both **ESM** and **CommonJS** module systems, because we're not ~~monsters~~ ~~pedants~~ _ideologues_ about this sort of thing.
 


### PR DESCRIPTION
BREAKING CHANGES: Minimum required version of Node.js is now v22.13.0. Node.js v23.0.0 support has been dropped.