### PR TITLE
feat(property-testing): expose rejectPassing

### DIFF
--- a/packages/bupkis/test/property/configs/sync-parametric-config.ts
+++ b/packages/bupkis/test/property/configs/sync-parametric-config.ts
@@ -4,6 +4,7 @@ import {
   hasValueDeep,
   objectFilter,
   type PropertyTestConfig,
+  rejectPassing,
   safeRegexStringFilter,
 } from '@bupkis/property-testing';
 import escapeStringRegexp from 'escape-string-regexp';
@@ -12,6 +13,7 @@ import fc from 'fast-check';
 import * as assertions from '../../../src/assertion/impl/sync-parametric.js';
 import { type AnyAssertion } from '../../../src/types.js';
 import { SyncParametricGenerators } from '../../../test-data/sync-parametric-generators.js';
+import { expect } from '../../custom-assertions.js';
 
 /**
  * Arbitrary that generates any primitive value except `NaN` because `NaN !==
@@ -40,47 +42,53 @@ export const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           [[42, 'to deep equal', 43]],
           [['hello', 'to deeply equal', 'world']],
         ],
-        generators: fc.oneof(
-          // Primitives that don't match
-          primitive.chain((expected) =>
-            fc.tuple(
-              primitive.filter((actual) => actual !== expected),
-              fc.constantFrom(...extractPhrases(assertions.deepEqualAssertion)),
-              fc.constant(expected),
-            ),
-          ),
-          // Objects that don't match; medium objects should always generally be larger than small objects
-          fc
-            .object({ size: 'small' })
-            .filter(objectFilter)
-            .chain((expected) =>
+        generators: fc
+          .oneof(
+            // Primitives that don't match
+            primitive.chain((expected) =>
               fc.tuple(
-                fc.object({ size: 'medium' }).filter(objectFilter),
+                primitive.filter((actual) => actual !== expected),
                 fc.constantFrom(
                   ...extractPhrases(assertions.deepEqualAssertion),
                 ),
                 fc.constant(expected),
               ),
             ),
-          // Arrays that don't match
-          fc
-            .array(filteredAnything, {
-              minLength: 1,
-              size: 'small',
-            })
-            .chain((expected) =>
-              fc.tuple(
-                fc.array(filteredAnything, {
-                  minLength: 1,
-                  size: 'medium',
-                }),
-                fc.constantFrom(
-                  ...extractPhrases(assertions.deepEqualAssertion),
+            // Objects that don't match; medium objects should always generally be larger than small objects
+            fc
+              .object({ size: 'small' })
+              .filter(objectFilter)
+              .chain((expected) =>
+                fc.tuple(
+                  fc.object({ size: 'medium' }).filter(objectFilter),
+                  fc.constantFrom(
+                    ...extractPhrases(assertions.deepEqualAssertion),
+                  ),
+                  fc.constant(expected),
                 ),
-                fc.constant(expected),
               ),
-            ),
-        ),
+            // Arrays that don't match
+            fc
+              .array(filteredAnything, {
+                minLength: 1,
+                size: 'small',
+              })
+              .chain((expected) =>
+                fc.tuple(
+                  fc.array(filteredAnything, {
+                    minLength: 1,
+                    size: 'medium',
+                  }),
+                  fc.constantFrom(
+                    ...extractPhrases(assertions.deepEqualAssertion),
+                  ),
+                  fc.constant(expected),
+                ),
+              ),
+          )
+          // Belt-and-suspenders: independently-generated actual/expected pairs
+          // can shrink toward equality, so drop any tuple the assertion accepts.
+          .filter(rejectPassing(expect)),
         verbose: true,
       },
       valid: {
@@ -505,46 +513,54 @@ export const testConfigs = new Map<AnyAssertion, PropertyTestConfig>([
           [[42, 'to satisfy', 43]],
           [['hello', 'satisfies', 'world']],
         ],
-        generators: fc.oneof(
-          // Primitives that don't match
-          primitive.chain((expected) =>
-            fc.tuple(
-              primitive.filter((actual) => actual !== expected),
-              fc.constantFrom(...extractPhrases(assertions.satisfiesAssertion)),
-              fc.constant(expected),
-            ),
-          ),
-          // Objects that don't satisfy
-          fc
-            .object({ depthSize: 'small' })
-            .filter(objectFilter)
-            .chain((expected) =>
+        generators: fc
+          .oneof(
+            // Primitives that don't match
+            primitive.chain((expected) =>
               fc.tuple(
-                fc.object({ depthSize: 'medium' }).filter(objectFilter),
+                primitive.filter((actual) => actual !== expected),
                 fc.constantFrom(
                   ...extractPhrases(assertions.satisfiesAssertion),
                 ),
                 fc.constant(expected),
               ),
             ),
-          // Arrays that don't satisfy
-          fc
-            .array(filteredAnything, { minLength: 1, size: 'small' })
-            .chain((expected) =>
-              fc.tuple(
-                fc
-                  .array(filteredAnything, {
-                    minLength: 1,
-                    size: 'medium',
-                  })
-                  .filter((val) => !hasValueDeep(val, [])),
-                fc.constantFrom(
-                  ...extractPhrases(assertions.satisfiesAssertion),
+            // Objects that don't satisfy
+            fc
+              .object({ depthSize: 'small' })
+              .filter(objectFilter)
+              .chain((expected) =>
+                fc.tuple(
+                  fc.object({ depthSize: 'medium' }).filter(objectFilter),
+                  fc.constantFrom(
+                    ...extractPhrases(assertions.satisfiesAssertion),
+                  ),
+                  fc.constant(expected),
                 ),
-                fc.constant(expected),
               ),
-            ),
-        ),
+            // Arrays that don't satisfy
+            fc
+              .array(filteredAnything, { minLength: 1, size: 'small' })
+              .chain((expected) =>
+                fc.tuple(
+                  fc
+                    .array(filteredAnything, {
+                      minLength: 1,
+                      size: 'medium',
+                    })
+                    .filter((val) => !hasValueDeep(val, [])),
+                  fc.constantFrom(
+                    ...extractPhrases(assertions.satisfiesAssertion),
+                  ),
+                  fc.constant(expected),
+                ),
+              ),
+          )
+          // "to satisfy" is a subset check, so independently-generated pairs can
+          // coincidentally satisfy (and the shrinker actively seeks those out).
+          // Reject any tuple the assertion actually accepts so that "invalid"
+          // inputs remain genuinely invalid.
+          .filter(rejectPassing(expect)),
         verbose: true,
       },
       valid: {

--- a/packages/property-testing/README.md
+++ b/packages/property-testing/README.md
@@ -272,6 +272,23 @@ Removes regex metacharacters from a string. Useful when generating strings that 
 fc.string().map(safeRegexStringFilter);
 ```
 
+#### `rejectPassing(expectFn)`
+
+Builds a filter predicate that drops any `[subject, phrase, ...params]` tuple the assertion _accepts_. Apply it to invalid generators for subset-style assertions (`to satisfy`, `to be like`) where independently-generated subject/params pairs can coincidentally satisfy — and where `fast-check`'s shrinker will actively hunt for that overlap.
+
+```ts
+import { expect } from 'bupkis';
+import { rejectPassing } from '@bupkis/property-testing';
+
+const invalidArgs = fc
+  .oneof(objectsThatUsuallyDoNotSatisfy, arraysThatUsuallyDoNotSatisfy)
+  .filter(rejectPassing(expect));
+```
+
+Throws a `TypeError` if `expectFn` returns a `PromiseLike` — `fc.Arbitrary.filter` is synchronous, so async expect functions are not supported.
+
+This function does not catch rejections from any `PromiseLike` erroneously returned by `expectFn`.
+
 #### `calculateNumRuns(runSize?)`
 
 Calculates the number of test runs based on the environment:

--- a/packages/property-testing/src/index.ts
+++ b/packages/property-testing/src/index.ts
@@ -88,5 +88,6 @@ export {
   hasKeyDeep,
   hasValueDeep,
   objectFilter,
+  rejectPassing,
   safeRegexStringFilter,
 } from './util.js';

--- a/packages/property-testing/src/util.ts
+++ b/packages/property-testing/src/util.ts
@@ -192,6 +192,63 @@ export const safeRegexStringFilter = (str: string) =>
   str.replace(/[[\](){}^$*+?.\\|]/g, '');
 
 /**
+ * Builds a fast-check tuple filter that rejects assertion-argument tuples for
+ * which the assertion actually _passes_.
+ *
+ * "Invalid" generators commonly build `[subject, phrase, ...params]` tuples by
+ * generating the subject and params independently, assuming the result won't
+ * satisfy the assertion. That assumption breaks for _subset-style_ assertions
+ * such as `to satisfy`/`to be like`: a superset subject legitimately passes,
+ * and fast-check's shrinker actively drives generated values toward that
+ * overlap (e.g. collapsing both sides to `{ '': null }`). Filtering with this
+ * guard keeps an "invalid" generator's outputs genuinely invalid.
+ *
+ * The returned predicate invokes `expectFn` once per generated (and shrunk)
+ * tuple, so pass the same bound `expect` the assertion is tested with. Because
+ * `fc.Arbitrary.filter` is synchronous, this guard only supports synchronous
+ * assertions.
+ *
+ * @example
+ *
+ * ```ts
+ * import { expect } from 'bupkis';
+ *
+ * const invalidArgs = fc
+ *   .oneof(objectsThatUsuallyDoNotSatisfy, arraysThatUsuallyDoNotSatisfy)
+ *   .filter(rejectPassing(expect));
+ * ```
+ *
+ * @function
+ * @param expectFn The synchronous `expect` function used to evaluate each tuple
+ * @returns A predicate suitable for `fc.Arbitrary.filter` over argument tuples
+ *   of the form `[subject, phrase, ...params]`
+ * @group Generator Utilities
+ */
+export const rejectPassing =
+  (
+    expectFn: (value: unknown, ...args: [phrase: string, ...unknown[]]) => void,
+  ) =>
+  (
+    args: readonly [subject: unknown, phrase: string, ...unknown[]],
+  ): boolean => {
+    const [subject, ...rest] = args;
+    let result: unknown;
+    try {
+      result = expectFn(subject, ...rest);
+    } catch {
+      return true;
+    }
+    if (
+      typeof (result as PromiseLike<unknown> | undefined)?.then === 'function'
+    ) {
+      throw new TypeError(
+        'rejectPassing() only supports synchronous expect functions',
+      );
+    }
+    return false;
+  };
+
+/**
  * Predefined run sizes for property-based tests.
  */
 const RUN_SIZES = freeze({

--- a/packages/property-testing/test/util.test.ts
+++ b/packages/property-testing/test/util.test.ts
@@ -12,6 +12,7 @@ import {
   hasKeyDeep,
   hasValueDeep,
   objectFilter,
+  rejectPassing,
   safeRegexStringFilter,
 } from '../src/util.js';
 
@@ -635,6 +636,44 @@ describe('util', () => {
         expect(calculateNumRuns('medium'), 'to equal', 50);
         restoreEnv();
       });
+    });
+  });
+
+  describe('rejectPassing()', () => {
+    it('should keep tuples the assertion rejects (genuinely invalid)', () => {
+      const filter = rejectPassing(expect);
+      // 1 is not a string -> assertion throws -> tuple kept
+      expect(filter([1, 'to be a string']), 'to be true');
+    });
+
+    it('should reject tuples the assertion accepts (false positives)', () => {
+      const filter = rejectPassing(expect);
+      // 'hi' is a string -> assertion passes -> tuple dropped
+      expect(filter(['hi', 'to be a string']), 'to be false');
+    });
+
+    it('should reject coincidentally-satisfying subset-style tuples', () => {
+      const filter = rejectPassing(expect);
+      // superset subject satisfies the smaller expected -> dropped
+      expect(filter([{ a: 1, b: 2 }, 'to satisfy', { a: 1 }]), 'to be false');
+    });
+
+    it('should pass subject, phrase, and params through to expectFn', () => {
+      const calls: unknown[][] = [];
+      const spyExpect = (value: unknown, ...args: unknown[]) => {
+        calls.push([value, ...args]);
+      };
+      const filter = rejectPassing(spyExpect);
+      // spyExpect never throws, so every tuple is treated as passing -> dropped
+      expect(filter([42, 'to equal', 42]), 'to be false');
+      expect(calls, 'to deep equal', [[42, 'to equal', 42]]);
+    });
+
+    it('should throw TypeError when expectFn returns a Promise', () => {
+      const asyncExpect = async (_value: unknown, ..._args: unknown[]) => {};
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      const filter = rejectPassing(asyncExpect);
+      expect(() => filter(['hi', 'to be a string']), 'to throw a', TypeError);
     });
   });
 });


### PR DESCRIPTION
This exposes a new function `rejectPassing` which can be used as a filter for certain troublesome arbitraries.
