### PR TITLE
chore: add eslint-plugin-n

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import jsPlugin from '@eslint/js';
 import stylistic from '@stylistic/eslint-plugin';
 import eslintPluginJsonc from 'eslint-plugin-jsonc';
+import nodePlugin from 'eslint-plugin-n';
 import perfectionist from 'eslint-plugin-perfectionist';
 import zodPlugin from 'eslint-plugin-zod';
 import { defineConfig } from 'eslint/config';
@@ -10,7 +11,6 @@ import tseslint from 'typescript-eslint';
 import requireFunctionTagInArrowFunctions from './.config/eslint-rules/require-function-tag-in-arrow-functions.js';
 import requireIntrinsicDestructuring from './.config/eslint-rules/require-intrinsic-destructuring.js';
 
-// TODO: setup eslint-plugin-n
 export default defineConfig(
   jsPlugin.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
@@ -25,6 +25,7 @@ export default defineConfig(
     },
   },
   {
+    extends: ['n/recommended-module'],
     files: ['packages/**/src/**/*.ts'],
     plugins: {
       custom: {
@@ -37,6 +38,7 @@ export default defineConfig(
           ),
         },
       },
+      n: nodePlugin,
       zod: zodPlugin,
     },
     rules: {
@@ -66,6 +68,16 @@ export default defineConfig(
           ],
         },
       ],
+      'n/hashbang': [
+        'error',
+        { convertPath: { 'src/cli.ts': ['src/cli.ts', 'dist/cli.js'] } },
+      ],
+      'n/no-missing-import': [
+        'error',
+        {
+          ignoreTypeImport: true,
+        },
+      ],
       // Zod plugin rules
       'zod/array-style': ['error', { style: 'function' }],
       'zod/consistent-import-source': ['error', { sources: ['zod'] }],
@@ -86,6 +98,11 @@ export default defineConfig(
       'zod/require-error-message': 'off', // too noisy
       'zod/require-schema-suffix': 'off', // not our convention
       'zod/schema-error-property-style': 'error',
+    },
+    settings: {
+      n: {
+        allowModules: ['type-fest'],
+      },
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "escape-string-regexp": "5.0.0",
         "eslint": "9.39.4",
         "eslint-plugin-jsonc": "2.21.1",
+        "eslint-plugin-n": "18.1.0",
         "eslint-plugin-perfectionist": "5.9.1",
         "eslint-plugin-zod": "3.12.1",
         "fast-check": "4.5.2",
@@ -7403,6 +7404,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -8002,6 +8017,44 @@
         }
       }
     },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-es-x/node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-plugin-jsonc": {
       "version": "2.21.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.21.1.tgz",
@@ -8027,6 +8080,55 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.1.0.tgz",
+      "integrity": "sha512-hkUm9EtnFV2h2fE16jNVUfCVUqvPzI7fGLsFdun5lFt/pbmf2kCgDx6ymi9rx+NCUSggBmurJCZOfG20JBs/kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "globrex": "^0.1.2",
+        "ignore": "^5.3.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.57.1",
+        "ts-declaration-location": "^1.0.6",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-declaration-location": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
@@ -8843,6 +8945,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/git-raw-commits": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
@@ -8966,6 +9081,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -14897,6 +15019,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -16076,6 +16208,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terminal-link": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "escape-string-regexp": "5.0.0",
     "eslint": "9.39.4",
     "eslint-plugin-jsonc": "2.21.1",
+    "eslint-plugin-n": "18.1.0",
     "eslint-plugin-perfectionist": "5.9.1",
     "eslint-plugin-zod": "3.12.1",
     "fast-check": "4.5.2",

--- a/packages/codemod-core/tsconfig.json
+++ b/packages/codemod-core/tsconfig.json
@@ -4,8 +4,7 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "noEmit": false,
-    "rewriteRelativeImportExtensions": true
+    "noEmit": false
   },
   "exclude": ["node_modules", "dist", "test"],
   "extends": "../../tsconfig.json",

--- a/packages/events/src/assertions.ts
+++ b/packages/events/src/assertions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n/no-unsupported-features/node-builtins */
 /**
  * EventEmitter and EventTarget assertions for Bupkis.
  *

--- a/packages/from-assert/src/cli.ts
+++ b/packages/from-assert/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable n/no-process-exit */
 import { ansi, bargs, opt, pos } from '@boneskull/bargs';
 import {
   bupkisTheme,

--- a/packages/from-assert/tsconfig.json
+++ b/packages/from-assert/tsconfig.json
@@ -4,8 +4,7 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "noEmit": false,
-    "rewriteRelativeImportExtensions": true
+    "noEmit": false
   },
   "exclude": ["node_modules", "dist", "test"],
   "extends": "../../tsconfig.json",

--- a/packages/from-chai/src/cli.ts
+++ b/packages/from-chai/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable n/no-process-exit */
 import { ansi, bargs, opt, pos } from '@boneskull/bargs';
 import {
   bupkisTheme,

--- a/packages/from-chai/tsconfig.json
+++ b/packages/from-chai/tsconfig.json
@@ -4,8 +4,7 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "noEmit": false,
-    "rewriteRelativeImportExtensions": true
+    "noEmit": false
   },
   "exclude": ["node_modules", "dist", "test"],
   "extends": "../../tsconfig.json",

--- a/packages/from-jest/src/cli.ts
+++ b/packages/from-jest/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable n/no-process-exit */
 import { ansi, bargs, opt, pos } from '@boneskull/bargs';
 import {
   bupkisTheme,

--- a/packages/from-jest/tsconfig.json
+++ b/packages/from-jest/tsconfig.json
@@ -4,8 +4,7 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
-    "noEmit": false,
-    "rewriteRelativeImportExtensions": true
+    "noEmit": false
   },
   "exclude": ["node_modules", "dist", "test"],
   "extends": "../../tsconfig.json",

--- a/packages/msw/src/tracker.ts
+++ b/packages/msw/src/tracker.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n/no-unsupported-features/node-builtins */
 /**
  * Request tracking wrapper for MSW servers.
  *

--- a/packages/msw/src/types.ts
+++ b/packages/msw/src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n/no-unsupported-features/node-builtins */
 /**
  * Type definitions for MSW request tracking.
  *


### PR DESCRIPTION
### chore: lint by way of disabling rules!

Also fixes problematic/unused use of `rewriteRelativeImportExtensions` in various `tsconfig.json` files which were causing linting issues.

### chore: add eslint-plugin-n

Configures `eslint-plugin-n`.
