### PR TITLE
chore(ci): refactor publishing workflows into separate publish and pack actions

### DIFF
--- a/.github/actions/pack/action.yml
+++ b/.github/actions/pack/action.yml
@@ -1,0 +1,55 @@
+name: Pack npm workspaces
+description: >
+  Builds and packs one or more npm workspace packages into tarballs, then
+  uploads them as a workflow artifact. Intended to run after checkout and
+  before a separate, isolated publish job.
+
+inputs:
+  paths-released:
+    description: >
+      JSON array of workspace paths to pack
+      (e.g. '["packages/bupkis","packages/sinon"]').
+    required: true
+  node-version:
+    description: Node.js version to use.
+    required: false
+    default: '24.18.0'
+  artifact-name:
+    description: Name of the workflow artifact to upload.
+    required: false
+    default: bupkis-tarballs
+  artifact-retention-days:
+    description: Number of days to retain the uploaded artifact.
+    required: false
+    default: '1'
+
+outputs:
+  files:
+    description: JSON array of tarball filenames (basenames, not full paths).
+    value: ${{ steps.pack.outputs.files }}
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/prepare
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Pack workspaces
+      id: pack
+      shell: bash
+      env:
+        INPUT_PATHS_RELEASED: ${{ inputs.paths-released }}
+        INPUT_OUTDIR: ${{ runner.temp }}/bupkis-pack
+      run: |
+        mkdir -p "$INPUT_OUTDIR"
+        readarray -t workspace_args < <(jq -r '.[] | "--workspace=" + .' <<< "$INPUT_PATHS_RELEASED")
+        echo "Packing workspaces: ${workspace_args[*]}"
+        pack_output=$(npm pack "${workspace_args[@]}" --pack-destination="$INPUT_OUTDIR" --ignore-scripts --json --silent)
+        files=$(jq -c '[.[].filename]' <<< "$pack_output")
+        echo "files=$files" >> "$GITHUB_OUTPUT"
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/bupkis-pack
+        if-no-files-found: error
+        retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -1,38 +1,52 @@
 name: Publish
-description: Publish workspaces to npm
+description: >
+  Downloads a workflow artifact containing packed npm tarballs and publishes
+  each one to npm. No dev environment is required — this action is
+  intentionally isolated from dependencies.
 
 inputs:
   token:
-    description: 'npm token'
+    description: npm authentication token.
     required: true
-  paths-released:
-    description: 'JSON array of workspace paths to publish (from release-please paths_released output)'
-    required: true
+  artifact-name:
+    description: Name of the workflow artifact to download.
+    required: false
+    default: bupkis-tarballs
+  node-version:
+    description: Node.js version to use.
+    required: false
+    default: '24.18.0'
+  files:
+    description: >
+      JSON array of tarball filenames to publish (e.g. '["foo-1.0.0.tgz"]').
+      When omitted, all *.tgz files in the downloaded artifact are published.
+    required: false
+    default: ''
 
 runs:
+  using: composite
   steps:
-    # see https://github.com/google-github-actions/release-please-action#automating-publication-to-npm
-    # see https://docs.npmjs.com/generating-provenance-statements
-    - name: Checkout Repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        persist-credentials: false
-    - uses: ./.github/actions/prepare
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/bupkis-tarballs
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 24.18.0
-    - name: Publish workspaces to npm
+        node-version: ${{ inputs.node-version }}
+        registry-url: https://registry.npmjs.org
+    - name: Publish tarballs to npm
+      shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ inputs.token }}
-        INPUTS_PATHS_RELEASED: ${{ inputs.paths-released }}
+        INPUT_FILES: ${{ inputs.files }}
+        INPUT_DIR: ${{ runner.temp }}/bupkis-tarballs
       run: |
-        paths="${INPUTS_PATHS_RELEASED}"
-        if [ -z "$paths" ] || [ "$paths" = "[]" ]; then
-          echo "No paths to publish, nothing to do."
-          exit 0
+        if [ -n "$INPUT_FILES" ] && [ "$INPUT_FILES" != "[]" ]; then
+          mapfile -t tarballs < <(jq -r '.[]' <<< "$INPUT_FILES")
+        else
+          mapfile -t tarballs < <(cd "$INPUT_DIR" && ls -1 ./*.tgz)
         fi
-        for path in $(echo "$paths" | jq -r '.[]'); do
-          echo "Publishing workspace at $path..."
-          npm publish --workspace="$path" --access public
+        for f in "${tarballs[@]}"; do
+          echo "Publishing $f..."
+          npm publish "$INPUT_DIR/$(basename "$f")" --access public --provenance
         done
-      shell: bash
-  using: composite

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,30 +12,44 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  publish:
-    name: Run publish action
+  pack:
+    name: Pack workspaces
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
+    permissions: {}
+    outputs:
+      files: ${{ steps.pack.outputs.files }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Convert paths to JSON array
-        id: paths
-        run: |
-          # Convert comma-separated paths to JSON array
-          json=$(echo "$INPUTS_PATHS" | jq -cR 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
-          echo "json=$json" >> "$GITHUB_OUTPUT"
+        id: convert
         shell: bash
         env:
           INPUTS_PATHS: ${{ inputs.paths }}
+        run: |
+          json=$(echo "$INPUTS_PATHS" | jq -cR 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
+          echo "json=$json" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - id: pack
+        uses: ./.github/actions/pack
+        with:
+          paths-released: ${{ steps.convert.outputs.json }}
+
+  publish:
+    name: Publish workspaces
+    runs-on: ubuntu-latest
+    needs: pack
+    if: needs.pack.result == 'success' && needs.pack.outputs.files != '[]'
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/publish
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          paths-released: ${{ steps.paths.outputs.json }}
+          files: ${{ needs.pack.outputs.files }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release-please
+name: Release Please
 
 concurrency:
   group: ${{ github.workflow }}
@@ -12,23 +12,54 @@ permissions: {}
 
 jobs:
   release-please:
+    name: Release Please
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
-
-    name: Release Please
-    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
       - name: Create Release
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
-      - if: ${{ steps.release.outputs.releases_created }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+  pack:
+    name: Pack Released Workspaces
+    runs-on: ubuntu-latest
+    needs: release-please
+    concurrency:
+      group: pack-${{ github.ref }}
+      cancel-in-progress: false
+    if: needs.release-please.result == 'success' && needs.release-please.outputs.releases_created == 'true'
+    permissions: {}
+    outputs:
+      files: ${{ steps.pack.outputs.files }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - if: ${{ steps.release.outputs.releases_created }}
-        uses: ./.github/actions/publish
+      - id: pack
+        uses: ./.github/actions/pack
+        with:
+          paths-released: ${{ needs.release-please.outputs.paths_released }}
+
+  publish:
+    name: Publish Released Workspaces
+    runs-on: ubuntu-latest
+    needs: [release-please, pack]
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
+    if: needs.pack.result == 'success' && needs.pack.outputs.files != '[]'
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/publish
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          paths-released: ${{ steps.release.outputs.paths_released }}
+          files: ${{ needs.pack.outputs.files }}


### PR DESCRIPTION
This isolates the `npm publish` step from `node_modules` entirely, which mitigates a potential attack vector.